### PR TITLE
Wait till DB Healthy and Ready

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,18 @@
 # @see https://github.com/laravel/laravel/blob/11.x/.env.example for possible values
 APP_KEY=
+APP_USER_EMAIL: admin@example.com       # Only used for seeding the database
+APP_USER_PASSWORD: admin                # Only used for seeding the database
+SCRAPER_BASE_URL: http://scraper:3000   # Url to Name of the scrapper service
+AFFILIATE_ENABLED: 'true'               # See https://pricebuddy.jez.me/support-project.html
+
+MYSQL_DATABASE: pricebuddy
+MYSQL_USER: pricebuddy
+MYSQL_PASSWORD: pric3buddy              # Please change to something more secure
+MYSQL_ROOT_PASSWORD: root               # Please change to something more secure
+
+# End of user variables, dont touch below unless you know what your doing...
+DB_HOST: database                       # Name of the database service
+DB_USERNAME: ${MYSQL_USER}              # Dont touch, gets value from above variables
+DB_PASSWORD: ${MYSQL_PASSWORD}          # Dont touch, gets value from above variables
+DB_DATABASE: ${MYSQL_DATABASE}          # Dont touch, gets value from above variables
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,8 @@ services:
             APP_USER_PASSWORD: admin                # Only used for seeding the database
             SCRAPER_BASE_URL: http://scraper:3000   # Url to Name of the scrapper service
         depends_on:
-            - database
+          database:
+            condition: service_healthy
         networks:
             - default
 
@@ -30,6 +31,11 @@ services:
             MYSQL_USER: pricebuddy
             MYSQL_PASSWORD: pric3buddy
             MYSQL_ROOT_PASSWORD: root
+        healthcheck:
+          test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u${DB_USER}", "-p${DB_PASSWORD}" ]
+          interval: 10s
+          timeout: 5s
+          retries: 5
         volumes:
             - database:/var/lib/mysql
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,13 +27,15 @@ services:
 
     database:
         image: mysql:8.2
+        env_file:
+          - .env
         environment:
             MYSQL_DATABASE: pricebuddy
             MYSQL_USER: pricebuddy
             MYSQL_PASSWORD: pric3buddy
             MYSQL_ROOT_PASSWORD: root
         healthcheck:
-          test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u${DB_USER}", "-p${DB_PASSWORD}" ]
+          test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u${MYSQL_USER}", "-p${MYSQL_PASSWORD}" ]
           interval: 10s
           timeout: 5s
           retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,15 +10,8 @@ services:
         volumes:
             - storage:/app/storage
             - ./.env:/app/.env
-        environment:
-            DB_HOST: database                       # Name of the database service
-            DB_USERNAME: pricebuddy                 # Should match the MYSQL_USER in the database service
-            DB_PASSWORD: pric3buddy                 # Should match the MYSQL_PASSWORD in the database service
-            DB_DATABASE: pricebuddy                 # Should match the MYSQL_DATABASE in the database service
-            APP_USER_EMAIL: admin@example.com       # Only used for seeding the database
-            APP_USER_PASSWORD: admin                # Only used for seeding the database
-            SCRAPER_BASE_URL: http://scraper:3000   # Url to Name of the scrapper service
-            AFFILIATE_ENABLED: 'true'               # See https://pricebuddy.jez.me/support-project.html
+        env_file:
+          - .env
         depends_on:
           database:
             condition: service_healthy
@@ -29,11 +22,6 @@ services:
         image: mysql:8.2
         env_file:
           - .env
-        environment:
-            MYSQL_DATABASE: pricebuddy
-            MYSQL_USER: pricebuddy
-            MYSQL_PASSWORD: pric3buddy
-            MYSQL_ROOT_PASSWORD: root
         healthcheck:
           test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u${MYSQL_USER}", "-p${MYSQL_PASSWORD}" ]
           interval: 10s


### PR DESCRIPTION
I got annoyed with the app spamming the DB with connections before the database was up and running.

This push adds a healthcheck to wait and check for database to be ready to accept connections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved startup sequence to ensure the app service waits for the database to be fully healthy before starting.
  - Added a health check to the database service for more reliable service initialization.
  - Updated environment configuration examples with new variables for user credentials, database settings, scraper URL, and feature flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->