### PR TITLE
Fix PostgreSQL Database Compatibility

### DIFF
--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -106,10 +106,10 @@ class Store extends Model
         $first = array_shift($domains);
 
         return $query->where(function (Builder $subQuery) use ($first, $domains) {
-            $subQuery->whereJsonContains('domains', ['domain' => $first]);
+            $subQuery->whereJsonContains('domains', [['domain' => $first]]);
 
             foreach ($domains as $domain) {
-                $subQuery->orWhereJsonContains('domains', ['domain' => $domain]);
+                $subQuery->orWhereJsonContains('domains', [['domain' => $domain]]);
             }
         });
     }

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -170,7 +170,7 @@ class ScrapeUrl
 
     public function getStore(): ?Store
     {
-        $host = Uri::of($this->url)->host();
+        $host = strtolower(Uri::of($this->url)->host());
 
         return Store::query()->domainFilter($host)->oldest()->first();
     }

--- a/database/factories/StoreFactory.php
+++ b/database/factories/StoreFactory.php
@@ -48,12 +48,12 @@ class StoreFactory extends Factory
 
     public function forUrl(string $url): self
     {
-        $host = Uri::of($url)->host();
+        $host = strtolower(Uri::of($url)->host());
         $titleParts = explode('.', str_replace('www.', '', $host));
 
         return $this->state(fn (array $attributes) => [
             'name' => Str::title($titleParts[0] ?? $this->faker->word),
-            'domains' => ['domain' => Uri::of($url)->host()],
+            'domains' => ['domain' => strtolower(Uri::of($url)->host())],
         ]);
     }
 }

--- a/database/migrations/2025_04_15_185732_change_notifications_data_type_psql.php
+++ b/database/migrations/2025_04_15_185732_change_notifications_data_type_psql.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('ALTER TABLE notifications ALTER COLUMN data TYPE json USING data::json');
+       }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('ALTER TABLE notifications ALTER COLUMN data TYPE text USING data::text');
+       }
+    }
+};


### PR DESCRIPTION
This fixes the PostgreSQL compatibility.

I basically included 3 changes:
1. Safeguard the host uri to be cast to lowercase because PostgreSQL is case-sensitive and in most places the host uri was cast to lowercase, except in a few places
2. Fixes the notifications.data type from text to json for psql driver only. This was based on the error from Laravel log which required this type to be json for some operations that are performed on it.
3. Fixes the store `scopeDomainFilter ` query. PostgreSQL requires the object to be inside an array when querying json.

I tested these changes with PostgreSQL 16, PostgreSQL Alpine 16 and MYSQL 8.2. All were able to add a store and add products to this store.

Fixes #48