### PR TITLE
fix: image gets added when creating from seach results

### DIFF
--- a/app/Filament/Pages/AppSettingsPage.php
+++ b/app/Filament/Pages/AppSettingsPage.php
@@ -21,6 +21,7 @@ use Filament\Forms\Form;
 use Filament\Pages\SettingsPage;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\HtmlString;
+use Illuminate\Support\Once;
 
 class AppSettingsPage extends SettingsPage
 {
@@ -45,6 +46,7 @@ class AppSettingsPage extends SettingsPage
         parent::save();
 
         Cache::flush();
+        Once::flush();
     }
 
     public function form(Form $form): Form

--- a/app/Filament/Resources/ProductResource/Actions/AddSearchResultUrlBulkAction.php
+++ b/app/Filament/Resources/ProductResource/Actions/AddSearchResultUrlBulkAction.php
@@ -69,7 +69,7 @@ class AddSearchResultUrlBulkAction extends BulkAction
 
                         if ($url) {
                             // Set the product image to the first url that has an image.
-                            $resultImage = data_get($url->toArray(), 'scrape.image');
+                            $resultImage = data_get($result->toArray(), 'image');
                             if (! empty($resultImage) && empty($image)) {
                                 $image = $resultImage;
                             }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cache clearing when saving app settings to ensure all cached and memoized data is properly reset.
  - Updated product image selection during bulk actions to use the original search result’s image for greater accuracy.

- **Tests**
  - Enhanced search result tests to verify correct product creation, image assignment, and price after performing bulk actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->