### PR TITLE
fix: Add -z flag to nc command in start-app.sh

### DIFF
--- a/docker/php/start-app.sh
+++ b/docker/php/start-app.sh
@@ -22,8 +22,8 @@ php artisan storage:link
 php artisan config:clear
 php artisan optimize:clear
 
-# wait for the database t
-while ! nc ${DB_HOST:-database} ${DB_PORT:-3306}; do
+# wait for the database to be available
+while ! nc -z ${DB_HOST:-database} ${DB_PORT:-3306}; do
   >&2 echo "Database unavailable - sleeping"
   sleep 1
 done


### PR DESCRIPTION
Fixes #101

## Problem
The `nc` command without the `-z` flag causes the startup script to hang indefinitely when connecting to MySQL Router or certain MySQL configurations.

Without `-z`, netcat:
1. Connects to the MySQL server
2. Receives the MySQL protocol handshake greeting
3. Waits indefinitely for more data (MySQL expects the client to authenticate)

Discovered when migrated from MariaDB to MySQL (MariaDB works well with and without this flag).

## Solution
Add the `-z` flag to make `nc` scan without sending/receiving data. This is safe for both MariaDB and MySQL.

Also fixed a typo in the comment ('database t' -> 'database to be available').

## Testing
Tested with:
- MySQL 9.1.0 via MySQL Router (port 6446)
- MariaDB direct connection (port 3306)

Both work correctly with this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved application startup reliability by enhancing the database connectivity verification process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->