### PR TITLE
feat: Add og:price:amount price to default strategies

### DIFF
--- a/config/price_buddy.php
+++ b/config/price_buddy.php
@@ -44,6 +44,7 @@ return [
         'price' => [
             'selector' => [
                 'meta[property="product:price:amount"]|content',
+                'meta[property="og:price:amount"]|content',
                 '.a-price .a-offscreen',            // Amazon
                 '[itemProp="price"]|content',
                 '.price',


### PR DESCRIPTION
Armed with a slightly better understanding of how strategies are tested, and knowing that Shopify stores set this OG metadata for pricing, I'm proposing we add this selector to the default price extraction.

refs #107

Pushing the minimal change to see if tests pass!