### PR TITLE
#21 feat: add unit pricing support with factor 

### DIFF
--- a/app/Dto/PriceCacheDto.php
+++ b/app/Dto/PriceCacheDto.php
@@ -23,6 +23,10 @@ class PriceCacheDto
 
     private float $price;
 
+    private float $unitPrice;
+
+    private float $factor;
+
     private array $history;
 
     private ?Carbon $lastScrapeDate;
@@ -30,6 +34,8 @@ class PriceCacheDto
     private string $locale;
 
     private string $currency;
+
+    private ?string $unitOfMeasure;
 
     public function __construct(
         float $price,
@@ -42,6 +48,9 @@ class PriceCacheDto
         ?string $lastScrape = null,
         ?string $locale = null,
         ?string $currency = null,
+        ?float $unitPrice = null,
+        float $factor = 1,
+        ?string $unitOfMeasure = null,
     ) {
         $this->storeId = $storeId;
         $this->storeName = $storeName;
@@ -49,10 +58,13 @@ class PriceCacheDto
         $this->url = $url;
         $this->trend = $trend;
         $this->price = $price;
+        $this->unitPrice = $unitPrice ?? $price;
+        $this->factor = $factor;
         $this->history = $history;
         $this->lastScrapeDate = $lastScrape ? Carbon::parse($lastScrape) : null;
         $this->locale = $locale ?? CurrencyHelper::getLocale();
         $this->currency = $currency ?? CurrencyHelper::getCurrency();
+        $this->unitOfMeasure = $unitOfMeasure;
     }
 
     // Getters
@@ -104,6 +116,26 @@ class PriceCacheDto
     public function getPriceFormatted(): string
     {
         return CurrencyHelper::toString($this->getPrice(), locale: $this->locale, iso: $this->currency);
+    }
+
+    public function getUnitPrice(): float
+    {
+        return $this->unitPrice;
+    }
+
+    public function getUnitPriceFormatted(): string
+    {
+        return CurrencyHelper::toString($this->getUnitPrice(), locale: $this->locale, iso: $this->currency);
+    }
+
+    public function getUnitOfMeasure(): ?string
+    {
+        return $this->unitOfMeasure;
+    }
+
+    public function getFactor(): float
+    {
+        return $this->factor;
     }
 
     public function getHistory(int $count = 365): Collection
@@ -163,7 +195,10 @@ class PriceCacheDto
             $data['history'],
             $data['last_scrape'] ?? null,
             $data['locale'] ?? null,
-            $data['currency'] ?? null
+            $data['currency'] ?? null,
+            $data['unit_price'] ?? null,
+            $data['factor'] ?? 1,
+            $data['unit_of_measure'] ?? null,
         );
     }
 
@@ -180,12 +215,16 @@ class PriceCacheDto
             'trend_text' => $this->getTrendText(),
             'price' => $this->getPrice(),
             'price_formatted' => $this->getPriceFormatted(),
+            'unit_price' => $this->getUnitPrice(),
+            'unit_price_formatted' => $this->getUnitPriceFormatted(),
+            'factor' => $this->getFactor(),
             'history' => $this->getHistory(),
             'last_scrape' => $this->getLastScrapeDate(),
             'hours_since_last_scrape' => $this->getHoursSinceLastScrape(),
             'successful_last_scrape' => $this->isLastScrapeSuccessful(),
             'locale' => $this->locale,
             'currency' => $this->currency,
+            'unit_of_measure' => $this->getUnitOfMeasure(),
         ];
     }
 }

--- a/app/Dto/PriceCacheDto.php
+++ b/app/Dto/PriceCacheDto.php
@@ -25,7 +25,7 @@ class PriceCacheDto
 
     private float $unitPrice;
 
-    private float $factor;
+    private float $priceFactor;
 
     private array $history;
 
@@ -49,7 +49,7 @@ class PriceCacheDto
         ?string $locale = null,
         ?string $currency = null,
         ?float $unitPrice = null,
-        float $factor = 1,
+        float $priceFactor = 1,
         ?string $unitOfMeasure = null,
     ) {
         $this->storeId = $storeId;
@@ -59,7 +59,7 @@ class PriceCacheDto
         $this->trend = $trend;
         $this->price = $price;
         $this->unitPrice = $unitPrice ?? $price;
-        $this->factor = $factor;
+        $this->priceFactor = $priceFactor;
         $this->history = $history;
         $this->lastScrapeDate = $lastScrape ? Carbon::parse($lastScrape) : null;
         $this->locale = $locale ?? CurrencyHelper::getLocale();
@@ -133,9 +133,9 @@ class PriceCacheDto
         return $this->unitOfMeasure;
     }
 
-    public function getFactor(): float
+    public function getPriceFactor(): float
     {
-        return $this->factor;
+        return $this->priceFactor;
     }
 
     public function getHistory(int $count = 365): Collection
@@ -197,7 +197,7 @@ class PriceCacheDto
             $data['locale'] ?? null,
             $data['currency'] ?? null,
             $data['unit_price'] ?? null,
-            $data['factor'] ?? 1,
+            $data['price_factor'] ?? 1,
             $data['unit_of_measure'] ?? null,
         );
     }
@@ -217,7 +217,7 @@ class PriceCacheDto
             'price_formatted' => $this->getPriceFormatted(),
             'unit_price' => $this->getUnitPrice(),
             'unit_price_formatted' => $this->getUnitPriceFormatted(),
-            'factor' => $this->getFactor(),
+            'price_factor' => $this->getPriceFactor(),
             'history' => $this->getHistory(),
             'last_scrape' => $this->getLastScrapeDate(),
             'hours_since_last_scrape' => $this->getHoursSinceLastScrape(),

--- a/app/Filament/Resources/ProductResource.php
+++ b/app/Filament/Resources/ProductResource.php
@@ -110,10 +110,10 @@ class ProductResource extends Resource
                     ->hintIcon(Icons::Help->value, 'The Image URL of the product'),
 
                 TextInput::make('unit_of_measure')
-                    ->label('Unit of Measure')
-                    ->placeholder('e.g. tablet, item, 100g')
+                    ->label('Sold as')
+                    ->placeholder('e.g. tablets, bags, 100g')
                     ->maxLength(50)
-                    ->hintIcon(Icons::Help->value, 'Displayed after unit price, e.g. $5.00/tablet'),
+                    ->hintIcon(Icons::Help->value, 'Displayed after the price factor, e.g. (2 tablets)'),
 
                 Forms\Components\Select::make('status')
                     ->options(Statuses::class)

--- a/app/Filament/Resources/ProductResource.php
+++ b/app/Filament/Resources/ProductResource.php
@@ -102,6 +102,12 @@ class ProductResource extends Resource
                     ->label('Image Url')
                     ->hintIcon(Icons::Help->value, 'The Image URL of the product'),
 
+                TextInput::make('unit_of_measure')
+                    ->label('Unit of Measure')
+                    ->placeholder('e.g. tablet, item, 100g')
+                    ->maxLength(50)
+                    ->hintIcon(Icons::Help->value, 'Displayed after unit price, e.g. $5.00/tablet'),
+
                 Forms\Components\Select::make('status')
                     ->options(Statuses::class)
                     ->default(Statuses::Published)

--- a/app/Filament/Resources/ProductResource.php
+++ b/app/Filament/Resources/ProductResource.php
@@ -79,6 +79,13 @@ class ProductResource extends Resource
             ->hintIcon(Icons::Help->value, 'The domain of the URL must be in the list of available stores')
             ->rules([new StoreUrl]);
 
+        $components[] = TextInput::make('factor')
+            ->label(__('Factor'))
+            ->numeric()
+            ->default(1)
+            ->minValue(0.01)
+            ->helperText(__('Number of items (unit price = price / factor)'));
+
         $components[] = Forms\Components\Toggle::make('create_store')
             ->label('Create store if it doesn\'t exist')
             ->hintIcon(Icons::Help->value, 'Attempt to create automatically create a store. Does not always work')

--- a/app/Filament/Resources/ProductResource.php
+++ b/app/Filament/Resources/ProductResource.php
@@ -79,8 +79,8 @@ class ProductResource extends Resource
             ->hintIcon(Icons::Help->value, 'The domain of the URL must be in the list of available stores')
             ->rules([new StoreUrl]);
 
-        $components[] = TextInput::make('factor')
-            ->label(__('Factor'))
+        $components[] = TextInput::make('price_factor')
+            ->label(__('Price Factor'))
             ->numeric()
             ->default(1)
             ->minValue(0.01)

--- a/app/Filament/Resources/ProductResource/Actions/AddUrlAction.php
+++ b/app/Filament/Resources/ProductResource/Actions/AddUrlAction.php
@@ -36,6 +36,12 @@ class AddUrlAction extends Action
                 ->hiddenLabel(true)
                 ->placeholder('http://my-store.com/product')
                 ->rules([new StoreUrl]),
+            TextInput::make('factor')
+                ->label(__('Factor'))
+                ->numeric()
+                ->default(1)
+                ->minValue(0.01)
+                ->helperText(__('Number of items (unit price = price / factor)')),
         ]);
 
         $this->color('gray');
@@ -48,11 +54,17 @@ class AddUrlAction extends Action
             $product = $this->record;
 
             try {
-                Url::createFromUrl(
+                $urlModel = Url::createFromUrl(
                     url: $data['url'],
                     productId: $product->getKey(),
                     userId: auth()->id(),
                 );
+
+                if ($urlModel && ! empty($data['factor']) && $data['factor'] != 1) {
+                    $urlModel->update(['factor' => $data['factor']]);
+                    // Re-fetch price with the new factor applied.
+                    $urlModel->updatePrice();
+                }
 
                 $this->success();
                 $this->redirect($product->view_url);

--- a/app/Filament/Resources/ProductResource/Actions/AddUrlAction.php
+++ b/app/Filament/Resources/ProductResource/Actions/AddUrlAction.php
@@ -36,8 +36,8 @@ class AddUrlAction extends Action
                 ->hiddenLabel(true)
                 ->placeholder('http://my-store.com/product')
                 ->rules([new StoreUrl]),
-            TextInput::make('factor')
-                ->label(__('Factor'))
+            TextInput::make('price_factor')
+                ->label(__('Price Factor'))
                 ->numeric()
                 ->default(1)
                 ->minValue(0.01)
@@ -58,7 +58,7 @@ class AddUrlAction extends Action
                     url: $data['url'],
                     productId: $product->getKey(),
                     userId: auth()->id(),
-                    factor: (float) ($data['factor'] ?? 1),
+                    priceFactor: (float) ($data['price_factor'] ?? 1),
                 );
 
                 $this->success();

--- a/app/Filament/Resources/ProductResource/Actions/AddUrlAction.php
+++ b/app/Filament/Resources/ProductResource/Actions/AddUrlAction.php
@@ -58,13 +58,8 @@ class AddUrlAction extends Action
                     url: $data['url'],
                     productId: $product->getKey(),
                     userId: auth()->id(),
+                    factor: (float) ($data['factor'] ?? 1),
                 );
-
-                if ($urlModel && ! empty($data['factor']) && $data['factor'] != 1) {
-                    $urlModel->update(['factor' => $data['factor']]);
-                    // Re-fetch price with the new factor applied.
-                    $urlModel->updatePrice();
-                }
 
                 $this->success();
                 $this->redirect($product->view_url);

--- a/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
+++ b/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
@@ -23,7 +23,8 @@ class CreateProduct extends CreateRecord
             url: $url,
             productId: $productId,
             userId: auth()->id(),
-            createStore: data_get($data, 'create_store', false)
+            createStore: data_get($data, 'create_store', false),
+            factor: (float) data_get($data, 'factor', 1),
         );
 
         return $urlModel->product;

--- a/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
+++ b/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
@@ -24,7 +24,7 @@ class CreateProduct extends CreateRecord
             productId: $productId,
             userId: auth()->id(),
             createStore: data_get($data, 'create_store', false),
-            factor: (float) data_get($data, 'factor', 1),
+            priceFactor: (float) data_get($data, 'price_factor', 1),
         );
 
         return $urlModel->product;

--- a/app/Filament/Resources/ProductResource/Pages/EditProduct.php
+++ b/app/Filament/Resources/ProductResource/Pages/EditProduct.php
@@ -49,5 +49,7 @@ class EditProduct extends EditRecord
         $product = $this->record;
 
         $product->tags()->sync($this->data['tags']);
+        $product->refresh();
+        $product->updatePriceCache();
     }
 }

--- a/app/Filament/Resources/ProductResource/Pages/EditProduct.php
+++ b/app/Filament/Resources/ProductResource/Pages/EditProduct.php
@@ -43,13 +43,12 @@ class EditProduct extends EditRecord
         return 1;
     }
 
-    protected function afterUpdate(): void
+    protected function afterSave(): void
     {
         /** @var Product $product */
-        $product = $this->record;
+        $product = Product::find($this->record->getKey());
 
         $product->tags()->sync($this->data['tags']);
-        $product->refresh();
         $product->updatePriceCache();
     }
 }

--- a/app/Filament/Resources/ProductResource/Widgets/PriceHistoryChart.php
+++ b/app/Filament/Resources/ProductResource/Widgets/PriceHistoryChart.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\ProductResource\Widgets;
 
+use App\Dto\PriceCacheDto;
 use App\Models\Product;
 use App\Models\Url;
 use App\Providers\Filament\AdminPanelProvider;
@@ -35,18 +36,43 @@ class PriceHistoryChart extends ChartWidget
 
     protected static ?string $pollingInterval = null;
 
+    public ?string $filter = 'unit_price';
+
+    protected function getFilters(): ?array
+    {
+        return [
+            'unit_price' => 'Unit Price',
+            'retail_price' => 'Retail Price',
+        ];
+    }
+
     protected function getData(): array
     {
-        $history = $this->record->getPriceHistoryCached();
+        $priceCache = $this->record->getPriceCache();
+        $showUnitPrice = $this->filter === 'unit_price';
+
+        $history = $priceCache->mapWithKeys(fn (PriceCacheDto $price) => [
+            $price->getUrlId() => $price->getHistory(),
+        ]);
+
+        $priceFactors = $priceCache->mapWithKeys(fn (PriceCacheDto $price) => [
+            $price->getUrlId() => $price->getPriceFactor(),
+        ]);
 
         $datasets = [];
 
         $urls = Url::findMany($history->keys())->values();
 
         foreach ($urls as $idx => $url) {
+            $data = $history->get($url->id);
+            if ($showUnitPrice) {
+                $factor = $priceFactors->get($url->id, 1);
+                $data = $data->map(fn ($price) => round($price / $factor, 2));
+            }
+
             $datasets[] = [
                 'label' => $url->store?->name,
-                'data' => $history->get($url->id),
+                'data' => $data,
                 'backgroundColor' => 'rgba('.$this->getDatasetColor($idx).', 0.4)',
                 'borderColor' => 'rgba('.$this->getDatasetColor($idx).', 0.9)',
                 'fill' => true,

--- a/app/Filament/Resources/ProductResource/Widgets/ProductUrlStats.php
+++ b/app/Filament/Resources/ProductResource/Widgets/ProductUrlStats.php
@@ -9,6 +9,7 @@ use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
@@ -117,9 +118,11 @@ class ProductUrlStats extends BaseWidget implements HasActions, HasForms
                 ];
             })
             ->form([
-                TextInput::make('url')
+                Placeholder::make('url')
                     ->label('URL')
-                    ->disabled(),
+                    ->content(fn ($get) => new \Illuminate\Support\HtmlString(
+                        '<span style="cursor:pointer" x-on:click="const range = document.createRange(); range.selectNodeContents($el); const sel = window.getSelection(); sel.removeAllRanges(); sel.addRange(range)">'.e($get('url')).'</span>'
+                    )),
                 TextInput::make('price_factor')
                     ->label('Price Factor')
                     ->numeric()

--- a/app/Filament/Resources/ProductResource/Widgets/ProductUrlStats.php
+++ b/app/Filament/Resources/ProductResource/Widgets/ProductUrlStats.php
@@ -9,6 +9,7 @@ use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
+use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
@@ -97,6 +98,50 @@ class ProductUrlStats extends BaseWidget implements HasActions, HasForms
                         ->danger()->send();
                 }
 
+            });
+    }
+
+    public function editAction(): Action
+    {
+        return Action::make('edit')
+            ->size('sm')
+            ->color('gray')
+            ->icon('heroicon-o-pencil-square')
+            ->outlined(false)
+            ->fillForm(function ($arguments) {
+                $url = Url::find($arguments['url']);
+
+                return [
+                    'url' => $url->url,
+                    'price_factor' => $url->price_factor,
+                ];
+            })
+            ->form([
+                TextInput::make('url')
+                    ->label('URL')
+                    ->disabled(),
+                TextInput::make('price_factor')
+                    ->label('Price Factor')
+                    ->numeric()
+                    ->default(1)
+                    ->minValue(0.01)
+                    ->required(),
+            ])
+            ->action(function ($arguments, $data) {
+                $url = Url::find($arguments['url']);
+                $url->update(['price_factor' => $data['price_factor']]);
+                $url->updatePrice();
+                $url->product->updatePriceCache();
+
+                Notification::make('price_factor_updated')
+                    ->title('Price factor updated')
+                    ->success()
+                    ->send();
+
+                $backUrl = $url->product?->view_url;
+                if ($backUrl) {
+                    return redirect($backUrl);
+                }
             });
     }
 

--- a/app/Filament/Resources/ProductResource/Widgets/ProductUrlStats.php
+++ b/app/Filament/Resources/ProductResource/Widgets/ProductUrlStats.php
@@ -40,7 +40,7 @@ class ProductUrlStats extends BaseWidget implements HasActions, HasForms
             ->map(function (PriceCacheDto $cache, $idx) use ($product) {
                 return ProductUrlStat::make(
                     '@ '.$cache->getStoreName().($idx === 0 ? ' (Lowest price)' : ''),
-                    $cache->getPriceFormatted()
+                    $cache->getUnitPriceFormatted()
                 )->setPriceCache($idx, $cache, $product);
             })->values();
 

--- a/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
+++ b/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
@@ -59,6 +59,8 @@ class UrlsTableWidget extends BaseWidget
                             ->required(),
                     ])
                     ->after(function (Url $record) {
+                        // Recalculate the latest price with the new factor.
+                        $record->updatePrice();
                         $record->product->updatePriceCache();
 
                         Notification::make('factor_updated')

--- a/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
+++ b/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
@@ -37,8 +37,8 @@ class UrlsTableWidget extends BaseWidget
                             ->formatStateUsing(fn (string $state): HtmlString => new HtmlString('<a href="'.$state.'" title="'.$state.'" target="_blank">'.Str::limit($state, 80).'</a>')
                             ),
                     ]),
-                    Tables\Columns\TextColumn::make('factor')
-                        ->label('Factor')
+                    Tables\Columns\TextColumn::make('price_factor')
+                        ->label('Price Factor')
                         ->grow(false)
                         ->badge()
                         ->color('gray'),
@@ -51,8 +51,8 @@ class UrlsTableWidget extends BaseWidget
                         \Filament\Forms\Components\TextInput::make('url')
                             ->label('URL')
                             ->disabled(),
-                        \Filament\Forms\Components\TextInput::make('factor')
-                            ->label('Factor')
+                        \Filament\Forms\Components\TextInput::make('price_factor')
+                            ->label('Price Factor')
                             ->numeric()
                             ->default(1)
                             ->minValue(0.01)
@@ -63,8 +63,8 @@ class UrlsTableWidget extends BaseWidget
                         $record->updatePrice();
                         $record->product->updatePriceCache();
 
-                        Notification::make('factor_updated')
-                            ->title('Factor updated')
+                        Notification::make('price_factor_updated')
+                            ->title('Price factor updated')
                             ->success()
                             ->send();
                     }),

--- a/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
+++ b/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
@@ -3,6 +3,8 @@
 namespace App\Filament\Resources\ProductResource\Widgets;
 
 use App\Models\Product;
+use App\Models\Url;
+use Filament\Notifications\Notification;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Filament\Widgets\TableWidget as BaseWidget;
@@ -35,10 +37,35 @@ class UrlsTableWidget extends BaseWidget
                             ->formatStateUsing(fn (string $state): HtmlString => new HtmlString('<a href="'.$state.'" title="'.$state.'" target="_blank">'.Str::limit($state, 80).'</a>')
                             ),
                     ]),
+                    Tables\Columns\TextColumn::make('factor')
+                        ->label('Factor')
+                        ->grow(false)
+                        ->badge()
+                        ->color('gray'),
                 ]),
 
             ])
             ->actions([
+                Tables\Actions\EditAction::make()
+                    ->form([
+                        \Filament\Forms\Components\TextInput::make('url')
+                            ->label('URL')
+                            ->disabled(),
+                        \Filament\Forms\Components\TextInput::make('factor')
+                            ->label('Factor')
+                            ->numeric()
+                            ->default(1)
+                            ->minValue(0.01)
+                            ->required(),
+                    ])
+                    ->after(function (Url $record) {
+                        $record->product->updatePriceCache();
+
+                        Notification::make('factor_updated')
+                            ->title('Factor updated')
+                            ->success()
+                            ->send();
+                    }),
                 Tables\Actions\DeleteAction::make(),
             ])
             ->bulkActions([

--- a/app/Models/Price.php
+++ b/app/Models/Price.php
@@ -15,7 +15,7 @@ use Illuminate\Database\Eloquent\Relations\HasOneThrough;
  * @property ?Store $store
  * @property ?float $price
  * @property ?float $unit_price
- * @property float $factor
+ * @property float $price_factor
  * @property Carbon $created_at
  */
 class Price extends Model

--- a/app/Models/Price.php
+++ b/app/Models/Price.php
@@ -14,6 +14,8 @@ use Illuminate\Database\Eloquent\Relations\HasOneThrough;
  * @property ?Url $url
  * @property ?Store $store
  * @property ?float $price
+ * @property ?float $unit_price
+ * @property float $factor
  * @property Carbon $created_at
  */
 class Price extends Model

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -406,7 +406,7 @@ class Product extends Model
                     'url' => $url->buy_url,
                     'trend' => $trend,
                     'price' => $urlHistory->last(),
-                    'unit_price' => $lastScrapedPrice->unit_price ?? $urlHistory->last(),
+                    'unit_price' => $lastScrapedPrice?->unit_price ?? $urlHistory->last(),
                     'factor' => ($f = $url->factor ?: 1) == (int) $f ? (int) $f : $f,
                     'history' => $urlHistory->toArray(),
                     'last_scrape' => $lastScrapedTimestamp?->toDateTimeString(),

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -406,7 +406,7 @@ class Product extends Model
                     'url' => $url->buy_url,
                     'trend' => $trend,
                     'price' => $urlHistory->last(),
-                    'unit_price' => $lastScrapedPrice?->unit_price ?? $urlHistory->last(),
+                    'unit_price' => $lastScrapedPrice->unit_price ?? $urlHistory->last(),
                     'factor' => ($f = $url->factor ?: 1) == (int) $f ? (int) $f : $f,
                     'history' => $urlHistory->toArray(),
                     'last_scrape' => $lastScrapedTimestamp?->toDateTimeString(),
@@ -484,7 +484,7 @@ class Product extends Model
     public function updatePriceCache(): void
     {
         $priceCache = $this->buildPriceCache()->toArray();
-        $this->update(['price_cache' => $priceCache, 'current_price' => data_get($priceCache, '0.price', 0)]);
+        $this->update(['price_cache' => $priceCache, 'current_price' => data_get($priceCache, '0.unit_price', 0)]);
     }
 
     /**

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -407,7 +407,7 @@ class Product extends Model
                     'trend' => $trend,
                     'price' => $urlHistory->last(),
                     'unit_price' => $lastScrapedPrice->unit_price ?? $urlHistory->last(),
-                    'factor' => ($f = $url->factor ?: 1) == (int) $f ? (int) $f : $f,
+                    'price_factor' => ($f = $url->price_factor ?: 1) == (int) $f ? (int) $f : $f,
                     'history' => $urlHistory->toArray(),
                     'last_scrape' => $lastScrapedTimestamp?->toDateTimeString(),
                     'locale' => $store->locale,
@@ -454,7 +454,7 @@ class Product extends Model
                 'prices.id',
                 'prices.price',
                 'prices.unit_price',
-                'prices.factor',
+                'prices.price_factor',
                 'prices.created_at',
                 'urls.id as url_id',
                 'urls.store_id'

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -46,6 +46,7 @@ use Illuminate\Support\Str;
  * @property float $current_price
  * @property bool $is_last_scrape_successful
  * @property bool $is_notified_price
+ * @property ?string $unit_of_measure
  * @property Carbon $created_at
  * @property string $first_scrape_date
  */
@@ -344,7 +345,7 @@ class Product extends Model
     public function getPriceCache(): Collection
     {
         return collect($this->price_cache)
-            ->sortBy('price')
+            ->sortBy('unit_price')
             ->map(fn ($price) => PriceCacheDto::fromArray($price))
             ->values();
     }
@@ -405,13 +406,16 @@ class Product extends Model
                     'url' => $url->buy_url,
                     'trend' => $trend,
                     'price' => $urlHistory->last(),
+                    'unit_price' => $lastScrapedPrice->unit_price ?? $urlHistory->last(),
+                    'factor' => ($f = $url->factor ?: 1) == (int) $f ? (int) $f : $f,
                     'history' => $urlHistory->toArray(),
                     'last_scrape' => $lastScrapedTimestamp?->toDateTimeString(),
                     'locale' => $store->locale,
                     'currency' => $store->currency,
+                    'unit_of_measure' => $this->unit_of_measure,
                 ];
             })
-            ->sortBy('price')
+            ->sortBy('unit_price')
             ->values();
     }
 
@@ -449,6 +453,8 @@ class Product extends Model
             ->select(
                 'prices.id',
                 'prices.price',
+                'prices.unit_price',
+                'prices.factor',
                 'prices.created_at',
                 'urls.id as url_id',
                 'urls.store_id'

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -20,6 +20,7 @@ use Illuminate\Support\Str;
  * Product URL.
  *
  * @property ?string $url
+ * @property float $factor
  * @property string $product_name_short
  * @property string $store_name
  * @property string $buy_url
@@ -205,8 +206,13 @@ class Url extends Model
             return null;
         }
 
+        $priceFloat = CurrencyHelper::toFloat($price, locale: $this->store?->locale, iso: $this->store?->currency);
+        $factor = $this->factor ?: 1;
+
         return $this->prices()->create([
-            'price' => CurrencyHelper::toFloat($price, locale: $this->store?->locale, iso: $this->store?->currency),
+            'price' => $priceFloat,
+            'unit_price' => $priceFloat / $factor,
+            'factor' => $factor,
             'store_id' => $this->store_id,
         ]);
     }

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -148,7 +148,7 @@ class Url extends Model
         return $this->url ? ScrapeUrl::new($this->url)->scrape() : [];
     }
 
-    public static function createFromUrl(string $url, ?int $productId = null, ?int $userId = null, bool $createStore = true): Url|false
+    public static function createFromUrl(string $url, ?int $productId = null, ?int $userId = null, bool $createStore = true, float $factor = 1): Url|false
     {
         $userId = $userId ?? auth()->id();
 
@@ -185,6 +185,7 @@ class Url extends Model
             'url' => $url,
             'store_id' => $store->getKey(),
             'product_id' => $productId,
+            'factor' => $factor,
         ]);
 
         $urlModel->updatePrice(data_get($scrape, 'price'));

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Str;
  * Product URL.
  *
  * @property ?string $url
- * @property float $factor
+ * @property float $price_factor
  * @property string $product_name_short
  * @property string $store_name
  * @property string $buy_url
@@ -148,7 +148,7 @@ class Url extends Model
         return $this->url ? ScrapeUrl::new($this->url)->scrape() : [];
     }
 
-    public static function createFromUrl(string $url, ?int $productId = null, ?int $userId = null, bool $createStore = true, float $factor = 1): Url|false
+    public static function createFromUrl(string $url, ?int $productId = null, ?int $userId = null, bool $createStore = true, float $priceFactor = 1): Url|false
     {
         $userId = $userId ?? auth()->id();
 
@@ -185,7 +185,7 @@ class Url extends Model
             'url' => $url,
             'store_id' => $store->getKey(),
             'product_id' => $productId,
-            'factor' => $factor,
+            'price_factor' => $priceFactor,
         ]);
 
         $urlModel->updatePrice(data_get($scrape, 'price'));
@@ -208,12 +208,12 @@ class Url extends Model
         }
 
         $priceFloat = CurrencyHelper::toFloat($price, locale: $this->store?->locale, iso: $this->store?->currency);
-        $factor = $this->factor ?: 1;
+        $priceFactor = $this->price_factor ?: 1;
 
         return $this->prices()->create([
             'price' => $priceFloat,
-            'unit_price' => $priceFloat / $factor,
-            'factor' => $factor,
+            'unit_price' => $priceFloat / $priceFactor,
+            'price_factor' => $priceFactor,
             'store_id' => $this->store_id,
         ]);
     }

--- a/database/factories/PriceFactory.php
+++ b/database/factories/PriceFactory.php
@@ -21,7 +21,7 @@ class PriceFactory extends Factory
         return [
             'price' => 10.00,
             'unit_price' => 10.00,
-            'factor' => 1,
+            'price_factor' => 1,
             'url_id' => Url::factory(),
             'store_id' => Store::factory(),
         ];

--- a/database/factories/PriceFactory.php
+++ b/database/factories/PriceFactory.php
@@ -20,6 +20,8 @@ class PriceFactory extends Factory
     {
         return [
             'price' => 10.00,
+            'unit_price' => 10.00,
+            'factor' => 1,
             'url_id' => Url::factory(),
             'store_id' => Store::factory(),
         ];

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -31,26 +31,32 @@ class ProductFactory extends Factory
             'notify_percent' => $this->faker->randomFloat(2, 10, 100),
             'favourite' => true,
             'only_official' => $this->faker->boolean,
+            'unit_of_measure' => null,
             'price_cache' => [],
             'ignored_urls' => [],
             'user_id' => User::factory(),
         ];
     }
 
-    public function addUrlWithPrices(string $url, array $prices): self
+    public function addUrlWithPrices(string $url, array $prices, float $factor = 1): self
     {
-        return $this->afterCreating(function (Product $product) use ($url, $prices) {
+        return $this->afterCreating(function (Product $product) use ($url, $prices, $factor) {
             $store = ScrapeUrl::new($url)->getStore() ?? Store::factory()->forUrl($url)->createOne();
 
             /** @var Url $url */
             $url = $product->urls()->create([
                 'url' => $url,
                 'store_id' => $store->id,
+                'factor' => $factor,
             ]);
+
+            $urlFactor = $factor ?: 1;
 
             foreach ($prices as $idx => $price) {
                 $url->prices()->create([
                     'price' => $price,
+                    'unit_price' => $price / $urlFactor,
+                    'factor' => $urlFactor,
                     'store_id' => $store->id,
                     'created_at' => Carbon::now()->subDays(count($prices) - $idx)->setTime(6, 0)->toDateTimeString(),
                 ]);
@@ -78,8 +84,11 @@ class ProductFactory extends Factory
                 // Create prices.
                 $mutableDate = Carbon::now()->toMutable();
                 for ($p = 0; $p < $priceCount; $p++) {
+                    $priceValue = self::generateRandomPriceVariation($price);
                     $url->prices()->create([
-                        'price' => self::generateRandomPriceVariation($price),
+                        'price' => $priceValue,
+                        'unit_price' => $priceValue,
+                        'factor' => 1,
                         'store_id' => $store->id,
                         'created_at' => $mutableDate->subDay()->toDateTimeString(),
                     ]);

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -38,25 +38,25 @@ class ProductFactory extends Factory
         ];
     }
 
-    public function addUrlWithPrices(string $url, array $prices, float $factor = 1): self
+    public function addUrlWithPrices(string $url, array $prices, float $priceFactor = 1): self
     {
-        return $this->afterCreating(function (Product $product) use ($url, $prices, $factor) {
+        return $this->afterCreating(function (Product $product) use ($url, $prices, $priceFactor) {
             $store = ScrapeUrl::new($url)->getStore() ?? Store::factory()->forUrl($url)->createOne();
 
             /** @var Url $url */
             $url = $product->urls()->create([
                 'url' => $url,
                 'store_id' => $store->id,
-                'factor' => $factor,
+                'price_factor' => $priceFactor,
             ]);
 
-            $urlFactor = $factor ?: 1;
+            $urlPriceFactor = $priceFactor ?: 1;
 
             foreach ($prices as $idx => $price) {
                 $url->prices()->create([
                     'price' => $price,
-                    'unit_price' => $price / $urlFactor,
-                    'factor' => $urlFactor,
+                    'unit_price' => $price / $urlPriceFactor,
+                    'price_factor' => $urlPriceFactor,
                     'store_id' => $store->id,
                     'created_at' => Carbon::now()->subDays(count($prices) - $idx)->setTime(6, 0)->toDateTimeString(),
                 ]);
@@ -88,7 +88,7 @@ class ProductFactory extends Factory
                     $url->prices()->create([
                         'price' => $priceValue,
                         'unit_price' => $priceValue,
-                        'factor' => 1,
+                        'price_factor' => 1,
                         'store_id' => $store->id,
                         'created_at' => $mutableDate->subDay()->toDateTimeString(),
                     ]);

--- a/database/factories/UrlFactory.php
+++ b/database/factories/UrlFactory.php
@@ -24,7 +24,7 @@ class UrlFactory extends Factory
             'url' => $this->faker->url,
             'product_id' => Product::factory(),
             'store_id' => Store::factory(),
-            'factor' => 1,
+            'price_factor' => 1,
         ];
     }
 
@@ -32,13 +32,13 @@ class UrlFactory extends Factory
     {
         return $this->afterCreating(function (Url $url) use ($prices) {
 
-            $factor = $url->factor ?: 1;
+            $priceFactor = $url->price_factor ?: 1;
 
             foreach ($prices as $idx => $price) {
                 $url->prices()->create([
                     'price' => $price,
-                    'unit_price' => $price / $factor,
-                    'factor' => $factor,
+                    'unit_price' => $price / $priceFactor,
+                    'price_factor' => $priceFactor,
                     'store_id' => $url->store_id,
                     'created_at' => Carbon::now()->subDays(count($prices) - $idx)->setTime(6, 0)->toDateTimeString(),
                 ]);

--- a/database/factories/UrlFactory.php
+++ b/database/factories/UrlFactory.php
@@ -24,6 +24,7 @@ class UrlFactory extends Factory
             'url' => $this->faker->url,
             'product_id' => Product::factory(),
             'store_id' => Store::factory(),
+            'factor' => 1,
         ];
     }
 
@@ -31,9 +32,13 @@ class UrlFactory extends Factory
     {
         return $this->afterCreating(function (Url $url) use ($prices) {
 
+            $factor = $url->factor ?: 1;
+
             foreach ($prices as $idx => $price) {
                 $url->prices()->create([
                     'price' => $price,
+                    'unit_price' => $price / $factor,
+                    'factor' => $factor,
                     'store_id' => $url->store_id,
                     'created_at' => Carbon::now()->subDays(count($prices) - $idx)->setTime(6, 0)->toDateTimeString(),
                 ]);

--- a/database/migrations/2026_02_12_000000_add_factor_and_unit_price.php
+++ b/database/migrations/2026_02_12_000000_add_factor_and_unit_price.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('urls', function (Blueprint $table) {
+            $table->float('factor')->default(1)->after('store_id');
+        });
+
+        Schema::table('prices', function (Blueprint $table) {
+            $table->float('unit_price')->nullable()->after('price');
+            $table->float('factor')->default(1)->after('unit_price');
+        });
+
+        // Populate existing prices: factor is 1, so unit_price = price.
+        DB::table('prices')->update([
+            'unit_price' => DB::raw('price'),
+            'factor' => 1,
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('urls', function (Blueprint $table) {
+            $table->dropColumn('factor');
+        });
+
+        Schema::table('prices', function (Blueprint $table) {
+            $table->dropColumn(['unit_price', 'factor']);
+        });
+    }
+};

--- a/database/migrations/2026_02_12_161902_add_unit_of_measure_to_products_table.php
+++ b/database/migrations/2026_02_12_161902_add_unit_of_measure_to_products_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->string('unit_of_measure', 50)->nullable()->after('title');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('products', function (Blueprint $table) {
+            $table->dropColumn('unit_of_measure');
+        });
+    }
+};

--- a/database/migrations/2026_02_20_000000_rename_factor_to_price_factor.php
+++ b/database/migrations/2026_02_20_000000_rename_factor_to_price_factor.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('urls', function (Blueprint $table) {
+            $table->renameColumn('factor', 'price_factor');
+        });
+
+        Schema::table('prices', function (Blueprint $table) {
+            $table->renameColumn('factor', 'price_factor');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('urls', function (Blueprint $table) {
+            $table->renameColumn('price_factor', 'factor');
+        });
+
+        Schema::table('prices', function (Blueprint $table) {
+            $table->renameColumn('price_factor', 'factor');
+        });
+    }
+};

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -51,6 +51,20 @@ class ProductSeeder extends Seeder
             'image' => 'https://m.media-amazon.com/images/I/812-y3MIhmL._AC_SX679_PIbundle-2,TopRight,0,0_SH20_.jpg',
             'tag' => 'Household',
         ],
+        [
+            'title' => 'Lavazza Napoli Premium Coffee Beans 500g',
+            'urls' => [
+                'https://www.coles.com.au/product/lavazza-tales-of-italy-alluring-napoli-premium-coffee-beans-500g-6277834' => ['22', '24', '22', '19', '22'],
+                'https://www.woolworths.com.au/shop/productdetails/309483/lavazza-tales-of-italy-alluring-napoli-coffee-beans' => ['23', '21', '23', '20', '21'],
+                'https://www.amazon.com.au/Lavazza-Espresso-Chocolate-Intensity-Australia/dp/B0C1JWVRG5?tag=pricebuddy-22' => ['66', '63', '69', '57', '63'],
+            ],
+            'image' => 'https://cdn.productimages.coles.com.au/productimages/6/6277834.jpg',
+            'tag' => 'Household',
+            'unit_of_measure' => 'bag',
+            'factors' => [
+                'https://www.amazon.com.au/Lavazza-Espresso-Chocolate-Intensity-Australia/dp/B0C1JWVRG5?tag=pricebuddy-22' => 3,
+            ],
+        ],
     ];
 
     /**
@@ -87,15 +101,18 @@ class ProductSeeder extends Seeder
 
         foreach ($this->dummy as $productData) {
             $factory = Product::factory();
+            $factors = $productData['factors'] ?? [];
 
             foreach ($productData['urls'] as $url => $prices) {
-                $factory = $factory->addUrlWithPrices($url, $prices);
+                $factor = $factors[$url] ?? 1;
+                $factory = $factory->addUrlWithPrices($url, $prices, $factor);
             }
 
             /** @var Product $product */
             $product = $factory->createOne([
                 'title' => $productData['title'],
                 'image' => $productData['image'],
+                'unit_of_measure' => $productData['unit_of_measure'] ?? null,
                 'user_id' => $userId,
             ]);
 

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -61,7 +61,7 @@ class ProductSeeder extends Seeder
             'image' => 'https://cdn.productimages.coles.com.au/productimages/6/6277834.jpg',
             'tag' => 'Household',
             'unit_of_measure' => 'bags',
-            'factors' => [
+            'price_factors' => [
                 'https://www.amazon.com.au/Lavazza-Espresso-Chocolate-Intensity-Australia/dp/B0C1JWVRG5?tag=pricebuddy-22' => 3,
             ],
         ],
@@ -86,7 +86,7 @@ class ProductSeeder extends Seeder
             'image' => 'https://assets.woolworths.com.au/images/1005/618643.jpg?impolicy=wowsmkqiema&w=600&h=600',
             'tag' => 'Household',
             'unit_of_measure' => 'tablets',
-            'factors' => [
+            'price_factors' => [
                 'https://www.woolworths.com.au/shop/productdetails/618643/finish-ultimate-lemon-dishwasher-tablets' => 34,
                 'https://www.coles.com.au/product/finish-ultimate-dishwashing-tablets-lemon-sparkle-34-pack-7752503' => 34,
                 'https://www.woolworths.com.au/shop/productdetails/78637/finish-ultimate-lemon-dishwasher-tablets' => 16,
@@ -134,11 +134,11 @@ class ProductSeeder extends Seeder
 
         foreach ($this->dummy as $productData) {
             $factory = Product::factory();
-            $factors = $productData['factors'] ?? [];
+            $priceFactors = $productData['price_factors'] ?? [];
 
             foreach ($productData['urls'] as $url => $prices) {
-                $factor = $factors[$url] ?? 1;
-                $factory = $factory->addUrlWithPrices($url, $prices, $factor);
+                $priceFactor = $priceFactors[$url] ?? 1;
+                $factory = $factory->addUrlWithPrices($url, $prices, $priceFactor);
             }
 
             /** @var Product $product */

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -60,9 +60,42 @@ class ProductSeeder extends Seeder
             ],
             'image' => 'https://cdn.productimages.coles.com.au/productimages/6/6277834.jpg',
             'tag' => 'Household',
-            'unit_of_measure' => 'bag',
+            'unit_of_measure' => 'bags',
             'factors' => [
                 'https://www.amazon.com.au/Lavazza-Espresso-Chocolate-Intensity-Australia/dp/B0C1JWVRG5?tag=pricebuddy-22' => 3,
+            ],
+        ],
+        [
+            'title' => 'Finish Ultimate Lemon Dishwasher Tablets',
+            'urls' => [
+                // 34-pack
+                'https://www.woolworths.com.au/shop/productdetails/618643/finish-ultimate-lemon-dishwasher-tablets' => ['22', '20', '22', '18', '20', '20'],
+                'https://www.coles.com.au/product/finish-ultimate-dishwashing-tablets-lemon-sparkle-34-pack-7752503' => ['24', '22', '20', '22', '21', '20'],
+                // 16-pack
+                'https://www.woolworths.com.au/shop/productdetails/78637/finish-ultimate-lemon-dishwasher-tablets' => ['12', '11', '11.50', '12', '11', '10.50'],
+                'https://www.coles.com.au/product/finish-ultimate-lemon-dishwasher-tablets-16-pack-3679128' => ['23', '22', '23', '22.50', '22', '21'],
+                // 46-pack
+                'https://www.woolworths.com.au/shop/productdetails/148368/finish-ultimate-lemon-dishwasher-tablets' => ['27', '26', '25', '26', '25.50', '24.50'],
+                'https://www.coles.com.au/product/finish-ultimate-dishwasher-tablets-lemon-46-pack-3967235' => ['52', '50', '51', '50', '50', '49'],
+                // 62-pack
+                'https://www.woolworths.com.au/shop/productdetails/675840/finish-ultimate-lemon-dishwasher-tablets' => ['33', '32', '31', '32', '31', '30'],
+                'https://www.coles.com.au/product/finish-ultimate-dishwashing-tablets-lemon-sparkle-62-pack-7752489' => ['34', '33', '31', '32', '31', '30'],
+                // 70-pack
+                'https://www.woolworths.com.au/shop/productdetails/6019017/finish-ultimate-dishwasher-tablets-lemon' => ['35', '34', '33', '34', '33', '32'],
+            ],
+            'image' => 'https://assets.woolworths.com.au/images/1005/618643.jpg?impolicy=wowsmkqiema&w=600&h=600',
+            'tag' => 'Household',
+            'unit_of_measure' => 'tablets',
+            'factors' => [
+                'https://www.woolworths.com.au/shop/productdetails/618643/finish-ultimate-lemon-dishwasher-tablets' => 34,
+                'https://www.coles.com.au/product/finish-ultimate-dishwashing-tablets-lemon-sparkle-34-pack-7752503' => 34,
+                'https://www.woolworths.com.au/shop/productdetails/78637/finish-ultimate-lemon-dishwasher-tablets' => 16,
+                'https://www.coles.com.au/product/finish-ultimate-lemon-dishwasher-tablets-16-pack-3679128' => 16,
+                'https://www.woolworths.com.au/shop/productdetails/148368/finish-ultimate-lemon-dishwasher-tablets' => 46,
+                'https://www.coles.com.au/product/finish-ultimate-dishwasher-tablets-lemon-46-pack-3967235' => 46,
+                'https://www.woolworths.com.au/shop/productdetails/675840/finish-ultimate-lemon-dishwasher-tablets' => 62,
+                'https://www.coles.com.au/product/finish-ultimate-dishwashing-tablets-lemon-sparkle-62-pack-7752489' => 62,
+                'https://www.woolworths.com.au/shop/productdetails/6019017/finish-ultimate-dishwasher-tablets-lemon' => 70,
             ],
         ],
     ];

--- a/resources/views/components/prices-column.blade.php
+++ b/resources/views/components/prices-column.blade.php
@@ -43,7 +43,7 @@
                     <div class="hover:underline {{ $color }}" @if ($idx > 0) style="{{ Filament\Support\get_color_css_variables(Color::Gray, shades: [300, 500, 400, 600, 800]) }}" @endif>
                         <strong class="text-[1.2em] font-bold">{{ $cache->getUnitPriceFormatted() }}</strong>
                         @if ($cache->getFactor() != 1)
-                            <span class="text-xs text-gray-400 dark:text-gray-500">{{ $cache->getPriceFormatted() }} ({{ (int) $cache->getFactor() }} {{ $cache->getUnitOfMeasure() ?? 'pk' }})</span>
+                            <span class="text-xs text-gray-400 dark:text-gray-500">{{ $cache->getPriceFormatted() }} ({{ rtrim(rtrim($cache->getFactor(), '0'), '.') }} {{ $cache->getUnitOfMeasure() ?? 'pk' }})</span>
                         @endif
                         ({{ $cache->getStoreName() }})
                     </div>

--- a/resources/views/components/prices-column.blade.php
+++ b/resources/views/components/prices-column.blade.php
@@ -43,7 +43,7 @@
                     <div class="hover:underline {{ $color }}" @if ($idx > 0) style="{{ Filament\Support\get_color_css_variables(Color::Gray, shades: [300, 500, 400, 600, 800]) }}" @endif>
                         <strong class="text-[1.2em] font-bold">{{ $cache->getUnitPriceFormatted() }}</strong>
                         @if ($cache->getFactor() != 1)
-                            <span class="text-xs text-gray-400 dark:text-gray-500">{{ $cache->getPriceFormatted() }} ({{ rtrim(rtrim($cache->getFactor(), '0'), '.') }} {{ $cache->getUnitOfMeasure() ?? 'pk' }})</span>
+                            <span class="text-xs text-gray-400 dark:text-gray-500">{{ $cache->getPriceFormatted() }} ({{ (float) $cache->getFactor() }} {{ $cache->getUnitOfMeasure() ?? 'pk' }})</span>
                         @endif
                         ({{ $cache->getStoreName() }})
                     </div>

--- a/resources/views/components/prices-column.blade.php
+++ b/resources/views/components/prices-column.blade.php
@@ -42,8 +42,8 @@
 
                     <div class="hover:underline {{ $color }}" @if ($idx > 0) style="{{ Filament\Support\get_color_css_variables(Color::Gray, shades: [300, 500, 400, 600, 800]) }}" @endif>
                         <strong class="text-[1.2em] font-bold">{{ $cache->getUnitPriceFormatted() }}</strong>
-                        @if ($cache->getFactor() != 1)
-                            <span class="text-xs text-gray-400 dark:text-gray-500">{{ $cache->getPriceFormatted() }} ({{ (float) $cache->getFactor() }} {{ $cache->getUnitOfMeasure() ?? 'pk' }})</span>
+                        @if ($cache->getPriceFactor() != 1)
+                            <span class="text-xs text-gray-400 dark:text-gray-500">{{ $cache->getPriceFormatted() }} ({{ (float) $cache->getPriceFactor() }} {{ $cache->getUnitOfMeasure() ?? 'pk' }})</span>
                         @endif
                         ({{ $cache->getStoreName() }})
                     </div>

--- a/resources/views/components/prices-column.blade.php
+++ b/resources/views/components/prices-column.blade.php
@@ -41,7 +41,10 @@
                     <x-filament::icon :icon="$cache->getTrendIcon()" class="w-4 {{ $color }}"/>
 
                     <div class="hover:underline {{ $color }}" @if ($idx > 0) style="{{ Filament\Support\get_color_css_variables(Color::Gray, shades: [300, 500, 400, 600, 800]) }}" @endif>
-                        <strong class="text-[1.2em] font-bold">{{ $cache->getPriceFormatted() }}</strong>
+                        <strong class="text-[1.2em] font-bold">{{ $cache->getUnitPriceFormatted() }}</strong>
+                        @if ($cache->getFactor() != 1)
+                            <span class="text-xs text-gray-400 dark:text-gray-500">{{ $cache->getPriceFormatted() }} ({{ (int) $cache->getFactor() }} {{ $cache->getUnitOfMeasure() ?? 'pk' }})</span>
+                        @endif
                         ({{ $cache->getStoreName() }})
                     </div>
 

--- a/resources/views/components/product-card.blade.php
+++ b/resources/views/components/product-card.blade.php
@@ -36,7 +36,7 @@
                         </span>
                         @if ($latestPrice->getFactor() != 1)
                             <span class="text-xs text-gray-400 dark:text-gray-500">
-                                {{ $latestPrice->getPriceFormatted() }} ({{ rtrim(rtrim($latestPrice->getFactor(), '0'), '.') }} {{ $latestPrice->getUnitOfMeasure() ?? 'pk' }})
+                                {{ $latestPrice->getPriceFormatted() }} ({{ (float) $latestPrice->getFactor() }} {{ $latestPrice->getUnitOfMeasure() ?? 'pk' }})
                             </span>
                         @endif
                         <span class="text-xs text-gray-500 dark:text-gray-400 font-bold display-block">

--- a/resources/views/components/product-card.blade.php
+++ b/resources/views/components/product-card.blade.php
@@ -36,7 +36,7 @@
                         </span>
                         @if ($latestPrice->getFactor() != 1)
                             <span class="text-xs text-gray-400 dark:text-gray-500">
-                                {{ $latestPrice->getPriceFormatted() }} ({{ (int) $latestPrice->getFactor() }} {{ $latestPrice->getUnitOfMeasure() ?? 'pk' }})
+                                {{ $latestPrice->getPriceFormatted() }} ({{ rtrim(rtrim($latestPrice->getFactor(), '0'), '.') }} {{ $latestPrice->getUnitOfMeasure() ?? 'pk' }})
                             </span>
                         @endif
                         <span class="text-xs text-gray-500 dark:text-gray-400 font-bold display-block">

--- a/resources/views/components/product-card.blade.php
+++ b/resources/views/components/product-card.blade.php
@@ -34,9 +34,9 @@
                         <span class="text-2xl font-semibold">
                             {{ $latestPrice->getUnitPriceFormatted() }}
                         </span>
-                        @if ($latestPrice->getFactor() != 1)
+                        @if ($latestPrice->getPriceFactor() != 1)
                             <span class="text-xs text-gray-400 dark:text-gray-500">
-                                {{ $latestPrice->getPriceFormatted() }} ({{ (float) $latestPrice->getFactor() }} {{ $latestPrice->getUnitOfMeasure() ?? 'pk' }})
+                                {{ $latestPrice->getPriceFormatted() }} ({{ (float) $latestPrice->getPriceFactor() }} {{ $latestPrice->getUnitOfMeasure() ?? 'pk' }})
                             </span>
                         @endif
                         <span class="text-xs text-gray-500 dark:text-gray-400 font-bold display-block">

--- a/resources/views/components/product-card.blade.php
+++ b/resources/views/components/product-card.blade.php
@@ -32,8 +32,13 @@
                     </h3>
                     <div>
                         <span class="text-2xl font-semibold">
-                            {{ $latestPrice->getPriceFormatted() }}
+                            {{ $latestPrice->getUnitPriceFormatted() }}
                         </span>
+                        @if ($latestPrice->getFactor() != 1)
+                            <span class="text-xs text-gray-400 dark:text-gray-500">
+                                {{ $latestPrice->getPriceFormatted() }} ({{ (int) $latestPrice->getFactor() }} {{ $latestPrice->getUnitOfMeasure() ?? 'pk' }})
+                            </span>
+                        @endif
                         <span class="text-xs text-gray-500 dark:text-gray-400 font-bold display-block">
                             {{ '@'.$latestPrice->getStoreName() }}
                         </span>

--- a/resources/views/filament/pages/product/price-stat.blade.php
+++ b/resources/views/filament/pages/product/price-stat.blade.php
@@ -56,10 +56,18 @@
     >
     <div class="flex mb-4 gap-4">
 
-        <div
-            class="fi-wi-stats-overview-stat-value {{ $firstCardValueStyle }}"
-        >
-            {{ $getValue() }}
+        <div>
+            <div
+                class="fi-wi-stats-overview-stat-value {{ $firstCardValueStyle }}"
+            >
+                {{ $getValue() }}
+            </div>
+            @if ($priceCache->getFactor() != 1)
+                <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    {{ __('Retail') }}: {{ $priceCache->getPriceFormatted() }}
+                    <span class="text-gray-400 dark:text-gray-500">({{ (int) $priceCache->getFactor() }} {{ $priceCache->getUnitOfMeasure() ?? 'pk' }})</span>
+                </div>
+            @endif
         </div>
 
         <div class="flex items-center gap-x-2 justify-start">

--- a/resources/views/filament/pages/product/price-stat.blade.php
+++ b/resources/views/filament/pages/product/price-stat.blade.php
@@ -65,7 +65,7 @@
             @if ($priceCache->getFactor() != 1)
                 <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     {{ __('Retail') }}: {{ $priceCache->getPriceFormatted() }}
-                    <span class="text-gray-400 dark:text-gray-500">({{ (int) $priceCache->getFactor() }} {{ $priceCache->getUnitOfMeasure() ?? 'pk' }})</span>
+                    <span class="text-gray-400 dark:text-gray-500">({{ rtrim(rtrim($priceCache->getFactor(), '0'), '.') }} {{ $priceCache->getUnitOfMeasure() ?? 'pk' }})</span>
                 </div>
             @endif
         </div>

--- a/resources/views/filament/pages/product/price-stat.blade.php
+++ b/resources/views/filament/pages/product/price-stat.blade.php
@@ -62,10 +62,10 @@
             >
                 {{ $getValue() }}
             </div>
-            @if ($priceCache->getFactor() != 1)
+            @if ($priceCache->getPriceFactor() != 1)
                 <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     {{ __('Retail') }}: {{ $priceCache->getPriceFormatted() }}
-                    <span class="text-gray-400 dark:text-gray-500">({{ (float) $priceCache->getFactor() }} {{ $priceCache->getUnitOfMeasure() ?? 'pk' }})</span>
+                    <span class="text-gray-400 dark:text-gray-500">({{ (float) $priceCache->getPriceFactor() }} {{ $priceCache->getUnitOfMeasure() ?? 'pk' }})</span>
                 </div>
             @endif
         </div>

--- a/resources/views/filament/pages/product/price-stat.blade.php
+++ b/resources/views/filament/pages/product/price-stat.blade.php
@@ -65,7 +65,7 @@
             @if ($priceCache->getFactor() != 1)
                 <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">
                     {{ __('Retail') }}: {{ $priceCache->getPriceFormatted() }}
-                    <span class="text-gray-400 dark:text-gray-500">({{ rtrim(rtrim($priceCache->getFactor(), '0'), '.') }} {{ $priceCache->getUnitOfMeasure() ?? 'pk' }})</span>
+                    <span class="text-gray-400 dark:text-gray-500">({{ (float) $priceCache->getFactor() }} {{ $priceCache->getUnitOfMeasure() ?? 'pk' }})</span>
                 </div>
             @endif
         </div>

--- a/resources/views/filament/pages/product/price-stat.blade.php
+++ b/resources/views/filament/pages/product/price-stat.blade.php
@@ -207,6 +207,7 @@
         <div class="pb-expandable-stat__actions px-3 pt-4 pb-3 flex gap-2 justify-start items-center text-gray-500 dark:text-gray-400">
             {{ ($this->viewAction)(['url' => $priceCache->getUrl()]) }}
             {{ ($this->fetchAction)(['url' => $priceCache->getUrlId()]) }}
+            {{ ($this->editAction)(['url' => $priceCache->getUrlId()]) }}
             {{ ($this->deleteAction)(['url' => $priceCache->getUrlId()]) }}
          </div>
         @include('components.price-aggregates', [

--- a/tests/Feature/Models/ProductTest.php
+++ b/tests/Feature/Models/ProductTest.php
@@ -231,12 +231,12 @@ class ProductTest extends TestCase
         Carbon::setTestNow(Carbon::create(2025, 1, 10));
         $product = Product::factory()
             ->addUrlWithPrices('https://example.com', [12, 18, 24])
-            ->createOne(['unit_of_measure' => 'tablet']);
+            ->createOne(['unit_of_measure' => 'tablets']);
 
         $priceCache = $product->buildPriceCache();
 
         $this->assertCount(1, $priceCache);
-        $this->assertSame('tablet', $priceCache->first()['unit_of_measure']);
+        $this->assertSame('tablets', $priceCache->first()['unit_of_measure']);
     }
 
     public function test_build_price_cache_unit_of_measure_null_by_default()

--- a/tests/Feature/Models/ProductTest.php
+++ b/tests/Feature/Models/ProductTest.php
@@ -151,18 +151,18 @@ class ProductTest extends TestCase
         $this->assertSame($base.'/fetch', $actionUrls['fetch']); // deprecated, uses livewire.
     }
 
-    public function test_price_cache_is_sorted_by_price()
+    public function test_price_cache_is_sorted_by_unit_price()
     {
         $product = Product::factory()->createOne(
             ['price_cache' => [
-                ['price' => 20, 'history' => []],
-                ['price' => 10, 'history' => []],
-                ['price' => 30, 'history' => []],
+                ['price' => 20, 'unit_price' => 20, 'history' => []],
+                ['price' => 10, 'unit_price' => 10, 'history' => []],
+                ['price' => 30, 'unit_price' => 30, 'history' => []],
             ]]);
 
         $priceCache = $product->getPriceCache();
-        $this->assertEquals(10.0, $priceCache->first()->getPrice());
-        $this->assertEquals(30.0, $priceCache->last()->getPrice());
+        $this->assertEquals(10.0, $priceCache->first()->getUnitPrice());
+        $this->assertEquals(30.0, $priceCache->last()->getUnitPrice());
     }
 
     public function test_price_cache_aggregate_calculates_correctly()
@@ -209,6 +209,46 @@ class ProductTest extends TestCase
 
         $product->updatePriceCache();
         $this->assertSame($priceCache->toArray(), $product->price_cache);
+    }
+
+    public function test_build_price_cache_includes_unit_price_and_factor()
+    {
+        Carbon::setTestNow(Carbon::create(2025, 1, 10));
+        $product = Product::factory()
+            ->addUrlWithPrices('https://example.com', [12, 18, 24], factor: 6)
+            ->createOne();
+
+        $priceCache = $product->buildPriceCache();
+
+        $this->assertCount(1, $priceCache);
+        $first = $priceCache->first();
+        $this->assertEquals(6, $first['factor']);
+        $this->assertEquals(4.0, $first['unit_price']);
+    }
+
+    public function test_build_price_cache_includes_unit_of_measure()
+    {
+        Carbon::setTestNow(Carbon::create(2025, 1, 10));
+        $product = Product::factory()
+            ->addUrlWithPrices('https://example.com', [12, 18, 24])
+            ->createOne(['unit_of_measure' => 'tablet']);
+
+        $priceCache = $product->buildPriceCache();
+
+        $this->assertCount(1, $priceCache);
+        $this->assertSame('tablet', $priceCache->first()['unit_of_measure']);
+    }
+
+    public function test_build_price_cache_unit_of_measure_null_by_default()
+    {
+        Carbon::setTestNow(Carbon::create(2025, 1, 10));
+        $product = Product::factory()
+            ->addUrlWithPrices('https://example.com', [12, 18, 24])
+            ->createOne();
+
+        $priceCache = $product->buildPriceCache();
+
+        $this->assertNull($priceCache->first()['unit_of_measure']);
     }
 
     public function test_all_prices_query_returns_correct_data()

--- a/tests/Feature/Models/ProductTest.php
+++ b/tests/Feature/Models/ProductTest.php
@@ -215,14 +215,14 @@ class ProductTest extends TestCase
     {
         Carbon::setTestNow(Carbon::create(2025, 1, 10));
         $product = Product::factory()
-            ->addUrlWithPrices('https://example.com', [12, 18, 24], factor: 6)
+            ->addUrlWithPrices('https://example.com', [12, 18, 24], priceFactor: 6)
             ->createOne();
 
         $priceCache = $product->buildPriceCache();
 
         $this->assertCount(1, $priceCache);
         $first = $priceCache->first();
-        $this->assertEquals(6, $first['factor']);
+        $this->assertEquals(6, $first['price_factor']);
         $this->assertEquals(4.0, $first['unit_price']);
     }
 

--- a/tests/Feature/Models/UrlTest.php
+++ b/tests/Feature/Models/UrlTest.php
@@ -88,7 +88,7 @@ class UrlTest extends TestCase
         $this->assertInstanceOf(Price::class, $priceModel);
         $this->assertEquals(100.0, $priceModel->price);
         $this->assertEquals(100.0, $priceModel->unit_price);
-        $this->assertEquals(1, $priceModel->factor);
+        $this->assertEquals(1, $priceModel->price_factor);
     }
 
     public function test_update_price_calculates_unit_price_with_factor()
@@ -98,7 +98,7 @@ class UrlTest extends TestCase
             'url' => self::TEST_URL,
             'product_id' => $product->id,
             'store_id' => $this->store->id,
-            'factor' => 6,
+            'price_factor' => 6,
         ]);
 
         $this->mockScrape('$12', 'foo');
@@ -108,7 +108,7 @@ class UrlTest extends TestCase
         $this->assertInstanceOf(Price::class, $priceModel);
         $this->assertEquals(12.0, $priceModel->price);
         $this->assertEquals(2.0, $priceModel->unit_price);
-        $this->assertEquals(6, $priceModel->factor);
+        $this->assertEquals(6, $priceModel->price_factor);
     }
 
     public function test_update_price_with_default_factor()
@@ -125,7 +125,7 @@ class UrlTest extends TestCase
         $this->assertInstanceOf(Price::class, $priceModel);
         $this->assertEquals(50.0, $priceModel->price);
         $this->assertEquals(50.0, $priceModel->unit_price);
-        $this->assertEquals(1, $priceModel->factor);
+        $this->assertEquals(1, $priceModel->price_factor);
     }
 
     public function test_update_price_with_invalid_data()

--- a/tests/Feature/Models/UrlTest.php
+++ b/tests/Feature/Models/UrlTest.php
@@ -87,6 +87,45 @@ class UrlTest extends TestCase
 
         $this->assertInstanceOf(Price::class, $priceModel);
         $this->assertEquals(100.0, $priceModel->price);
+        $this->assertEquals(100.0, $priceModel->unit_price);
+        $this->assertEquals(1, $priceModel->factor);
+    }
+
+    public function test_update_price_calculates_unit_price_with_factor()
+    {
+        $product = Product::factory()->create();
+        $url = Url::factory()->createOne([
+            'url' => self::TEST_URL,
+            'product_id' => $product->id,
+            'store_id' => $this->store->id,
+            'factor' => 6,
+        ]);
+
+        $this->mockScrape('$12', 'foo');
+
+        $priceModel = $url->updatePrice();
+
+        $this->assertInstanceOf(Price::class, $priceModel);
+        $this->assertEquals(12.0, $priceModel->price);
+        $this->assertEquals(2.0, $priceModel->unit_price);
+        $this->assertEquals(6, $priceModel->factor);
+    }
+
+    public function test_update_price_with_default_factor()
+    {
+        $product = Product::factory()->create();
+        $url = Url::factory()->createOne([
+            'url' => self::TEST_URL,
+            'product_id' => $product->id,
+            'store_id' => $this->store->id,
+        ]);
+
+        $priceModel = $url->updatePrice(50);
+
+        $this->assertInstanceOf(Price::class, $priceModel);
+        $this->assertEquals(50.0, $priceModel->price);
+        $this->assertEquals(50.0, $priceModel->unit_price);
+        $this->assertEquals(1, $priceModel->factor);
     }
 
     public function test_update_price_with_invalid_data()

--- a/tests/Unit/Dto/PriceCacheDtoTest.php
+++ b/tests/Unit/Dto/PriceCacheDtoTest.php
@@ -23,10 +23,10 @@ class PriceCacheDtoTest extends TestCase
             price: 10.00,
             unitPrice: 5.00,
             priceFactor: 2,
-            unitOfMeasure: 'tablet',
+            unitOfMeasure: 'tablets',
         );
 
-        $this->assertSame('tablet', $dto->getUnitOfMeasure());
+        $this->assertSame('tablets', $dto->getUnitOfMeasure());
     }
 
     public function test_unit_of_measure_null_by_default()

--- a/tests/Unit/Dto/PriceCacheDtoTest.php
+++ b/tests/Unit/Dto/PriceCacheDtoTest.php
@@ -22,7 +22,7 @@ class PriceCacheDtoTest extends TestCase
         $dto = new PriceCacheDto(
             price: 10.00,
             unitPrice: 5.00,
-            factor: 2,
+            priceFactor: 2,
             unitOfMeasure: 'tablet',
         );
 

--- a/tests/Unit/Dto/PriceCacheDtoTest.php
+++ b/tests/Unit/Dto/PriceCacheDtoTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Tests\Unit\Dto;
+
+use App\Dto\PriceCacheDto;
+use App\Services\Helpers\SettingsHelper;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+class PriceCacheDtoTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Artisan::call('migrate');
+        SettingsHelper::setSetting('default_locale_settings', ['locale' => 'en', 'currency' => 'USD']);
+    }
+
+    public function test_unit_of_measure_getter()
+    {
+        $dto = new PriceCacheDto(
+            price: 10.00,
+            unitPrice: 5.00,
+            factor: 2,
+            unitOfMeasure: 'tablet',
+        );
+
+        $this->assertSame('tablet', $dto->getUnitOfMeasure());
+    }
+
+    public function test_unit_of_measure_null_by_default()
+    {
+        $dto = new PriceCacheDto(
+            price: 10.00,
+            unitPrice: 10.00,
+        );
+
+        $this->assertNull($dto->getUnitOfMeasure());
+    }
+
+    public function test_from_array_includes_unit_of_measure()
+    {
+        $dto = PriceCacheDto::fromArray([
+            'price' => 10.00,
+            'history' => [],
+            'unit_of_measure' => 'item',
+        ]);
+
+        $this->assertSame('item', $dto->getUnitOfMeasure());
+    }
+
+    public function test_to_array_includes_unit_of_measure()
+    {
+        $dto = new PriceCacheDto(
+            price: 10.00,
+            unitOfMeasure: 'grams',
+        );
+
+        $array = $dto->toArray();
+        $this->assertSame('grams', $array['unit_of_measure']);
+    }
+
+    public function test_from_array_without_unit_of_measure_defaults_to_null()
+    {
+        $dto = PriceCacheDto::fromArray([
+            'price' => 10.00,
+            'history' => [],
+        ]);
+
+        $this->assertNull($dto->getUnitOfMeasure());
+    }
+}


### PR DESCRIPTION
Issue #21 

Add factor column to URLs table and unit_price/factor columns to prices table so that unit_price = price / factor is calculated on each scrape. Add unit_of_measure field to products (e.g. tablet, item, 100g) displayed in pack notation. Unit price is shown as the primary price throughout the UI, with retail price as a subheading when factor != 1. Price cache sorts by unit_price.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unit pricing with per‑URL pricing factors and product unit‑of‑measure; unit price shown throughout the UI with optional retail breakdown when factor ≠ 1.
  * Edit and creation flows allow entering/editing factor and unit‑of‑measure; factor updates refresh price caches and show a "Factor updated" notification.
* **Chores**
  * Database migrations and seed updates to add factor and unit_price fields.
* **Tests**
  * Updated and added tests covering unit_price, factor, and unit_of_measure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->