### PR TITLE
[#127] Add product availability tracking with stock status matching

### DIFF
--- a/app/Dto/PriceCacheDto.php
+++ b/app/Dto/PriceCacheDto.php
@@ -2,6 +2,7 @@
 
 namespace App\Dto;
 
+use App\Enums\StockStatus;
 use App\Enums\Trend;
 use App\Models\Price;
 use App\Models\Product;
@@ -31,6 +32,8 @@ class PriceCacheDto
 
     private string $currency;
 
+    private StockStatus $stockStatus;
+
     public function __construct(
         float $price,
         ?int $storeId = null,
@@ -42,6 +45,7 @@ class PriceCacheDto
         ?string $lastScrape = null,
         ?string $locale = null,
         ?string $currency = null,
+        ?string $availability = null,
     ) {
         $this->storeId = $storeId;
         $this->storeName = $storeName;
@@ -53,6 +57,7 @@ class PriceCacheDto
         $this->lastScrapeDate = $lastScrape ? Carbon::parse($lastScrape) : null;
         $this->locale = $locale ?? CurrencyHelper::getLocale();
         $this->currency = $currency ?? CurrencyHelper::getCurrency();
+        $this->stockStatus = StockStatus::fromScrapedValue($availability);
     }
 
     // Getters
@@ -144,6 +149,31 @@ class PriceCacheDto
         return $hours && $hours < 24;
     }
 
+    public function isOutOfStock(): bool
+    {
+        return $this->stockStatus->isUnavailable();
+    }
+
+    public function getStockStatus(): StockStatus
+    {
+        return $this->stockStatus;
+    }
+
+    public function getStockStatusLabel(): string
+    {
+        return $this->stockStatus->getLabel();
+    }
+
+    public function getStockStatusColor(): string
+    {
+        return $this->stockStatus->getColor();
+    }
+
+    public function getStockStatusIcon(): string
+    {
+        return $this->stockStatus->getIcon();
+    }
+
     public function matchesNotification(Product $product): bool
     {
         return $product->shouldNotifyOnPrice(new Price([
@@ -163,7 +193,8 @@ class PriceCacheDto
             $data['history'],
             $data['last_scrape'] ?? null,
             $data['locale'] ?? null,
-            $data['currency'] ?? null
+            $data['currency'] ?? null,
+            $data['availability'] ?? null,
         );
     }
 
@@ -186,6 +217,7 @@ class PriceCacheDto
             'successful_last_scrape' => $this->isLastScrapeSuccessful(),
             'locale' => $this->locale,
             'currency' => $this->currency,
+            'availability' => $this->stockStatus === StockStatus::InStock ? null : $this->stockStatus->value,
         ];
     }
 }

--- a/app/Dto/PriceCacheDto.php
+++ b/app/Dto/PriceCacheDto.php
@@ -149,7 +149,7 @@ class PriceCacheDto
         return $hours && $hours < 24;
     }
 
-    public function isOutOfStock(): bool
+    public function isUnavailable(): bool
     {
         return $this->stockStatus->isUnavailable();
     }

--- a/app/Enums/ScraperStrategyType.php
+++ b/app/Enums/ScraperStrategyType.php
@@ -40,7 +40,7 @@ enum ScraperStrategyType: string implements HasDescription, HasLabel
         };
     }
 
-    public static function getValueHelp(string $type): string
+    public static function getValueHelp(?string $type): string
     {
         return match ($type) {
             self::Selector->value => 'CSS selector to get the value. Use |attribute_name to get an attribute value instead of the element content',

--- a/app/Enums/StockStatus.php
+++ b/app/Enums/StockStatus.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Enums;
+
+use Filament\Support\Contracts\HasColor;
+use Filament\Support\Contracts\HasIcon;
+use Filament\Support\Contracts\HasLabel;
+
+enum StockStatus: string implements HasColor, HasIcon, HasLabel
+{
+    case InStock = 'in_stock';
+    case PreOrder = 'pre_order';
+    case BackOrder = 'back_order';
+    case SpecialOrder = 'special_order';
+    case OutOfStock = 'out_of_stock';
+    case Discontinued = 'discontinued';
+
+    public function getLabel(): string
+    {
+        return match ($this) {
+            self::InStock => 'In Stock',
+            self::PreOrder => 'Pre-Order',
+            self::BackOrder => 'Back Order',
+            self::SpecialOrder => 'Special Order',
+            self::OutOfStock => 'Out of Stock',
+            self::Discontinued => 'Discontinued',
+        };
+    }
+
+    public function getColor(): string
+    {
+        return match ($this) {
+            self::InStock => 'success',
+            self::PreOrder => 'info',
+            self::BackOrder, self::SpecialOrder => 'warning',
+            self::OutOfStock => 'danger',
+            self::Discontinued => 'gray',
+        };
+    }
+
+    public function getIcon(): string
+    {
+        return match ($this) {
+            self::InStock => 'heroicon-m-check-circle',
+            self::PreOrder => 'heroicon-m-clock',
+            self::BackOrder => 'heroicon-m-arrow-path',
+            self::SpecialOrder => 'heroicon-m-truck',
+            self::OutOfStock => 'heroicon-m-x-circle',
+            self::Discontinued => 'heroicon-m-archive-box-x-mark',
+        };
+    }
+
+    public function getSortOrder(): int
+    {
+        return match ($this) {
+            self::InStock => 0,
+            self::PreOrder => 1,
+            self::BackOrder => 2,
+            self::SpecialOrder => 3,
+            self::OutOfStock => 4,
+            self::Discontinued => 5,
+        };
+    }
+
+    /**
+     * Whether this status represents an unavailable item (anything other than InStock).
+     */
+    public function isUnavailable(): bool
+    {
+        return $this !== self::InStock;
+    }
+
+    /**
+     * Map a raw scraped value to a StockStatus enum case.
+     */
+    public static function fromScrapedValue(?string $value): self
+    {
+        if ($value === null || $value === '') {
+            return self::InStock;
+        }
+
+        // Try enum value string first (e.g. "out_of_stock").
+        $fromEnum = self::tryFrom($value);
+        if ($fromEnum !== null) {
+            return $fromEnum;
+        }
+
+        return match ($value) {
+            'OutOfStock' => self::OutOfStock,
+            'PreOrder' => self::PreOrder,
+            'BackOrder' => self::BackOrder,
+            'SpecialOrder' => self::SpecialOrder,
+            'Discontinued' => self::Discontinued,
+            default => self::OutOfStock,
+        };
+    }
+
+    /**
+     * Resolve a scraped value against a match config to determine stock status.
+     *
+     * @param  array<string, array{type?: string, value?: string}|string|null>|string|null  $matchConfig
+     */
+    public static function matchFromScrapedValue(?string $scrapedValue, array|string|null $matchConfig): self
+    {
+        if ($scrapedValue === null || $scrapedValue === '') {
+            return self::InStock;
+        }
+
+        // Legacy: flat string match → OutOfStock or InStock.
+        if (is_string($matchConfig)) {
+            return trim($scrapedValue) === trim($matchConfig) ? self::OutOfStock : self::InStock;
+        }
+
+        // Per-status match config: check each entry.
+        if (is_array($matchConfig)) {
+            $default = self::tryFrom($matchConfig['default'] ?? '') ?? self::InStock;
+
+            foreach ($matchConfig as $statusValue => $matchEntry) {
+                if ($statusValue === 'default' || $matchEntry === '' || $matchEntry === null) {
+                    continue;
+                }
+
+                // Support both new { type, value } format and legacy plain string.
+                if (is_array($matchEntry)) {
+                    $type = $matchEntry['type'] ?? 'match';
+                    $value = $matchEntry['value'] ?? '';
+
+                    if ($value === '') {
+                        continue;
+                    }
+
+                    $matched = self::valueMatches($scrapedValue, $value, $type);
+                } else {
+                    $matched = trim($scrapedValue) === trim((string) $matchEntry);
+                }
+
+                if ($matched) {
+                    $status = self::tryFrom($statusValue);
+                    if ($status !== null) {
+                        return $status;
+                    }
+                }
+            }
+
+            return $default;
+        }
+
+        // No match config: any non-empty value → OutOfStock.
+        return self::OutOfStock;
+    }
+
+    /**
+     * Check if a scraped value matches using the given type.
+     */
+    private static function valueMatches(string $scrapedValue, string $value, string $type): bool
+    {
+        if ($type === 'regex') {
+            $pattern = '~'.str_replace('~', '\~', $value).'~i';
+
+            return (bool) @preg_match($pattern, $scrapedValue);
+        }
+
+        return trim($scrapedValue) === trim($value);
+    }
+
+    /**
+     * All cases except InStock, for use in match config forms.
+     *
+     * @return array<int, self>
+     */
+    public static function nonInStockCases(): array
+    {
+        return array_values(array_filter(self::cases(), fn (self $case) => $case !== self::InStock));
+    }
+}

--- a/app/Enums/StockStatus.php
+++ b/app/Enums/StockStatus.php
@@ -86,6 +86,7 @@ enum StockStatus: string implements HasColor, HasIcon, HasLabel
         }
 
         return match ($value) {
+            'InStock' => self::InStock,
             'OutOfStock' => self::OutOfStock,
             'PreOrder' => self::PreOrder,
             'BackOrder' => self::BackOrder,

--- a/app/Filament/Concerns/HasScraperTrait.php
+++ b/app/Filament/Concerns/HasScraperTrait.php
@@ -15,22 +15,29 @@ use Illuminate\Support\HtmlString;
 
 trait HasScraperTrait
 {
-    protected static function makeStrategyInput(string $key, ?string $default = null): array
+    protected static function makeStrategyInput(string $key, ?string $default = null, bool $required = true): array
     {
+        $typeField = Select::make($key.'.type')
+            ->label('Type')
+            ->options(ScraperStrategyType::class)
+            ->default(ScraperStrategyType::Selector->value)
+            ->hintIcon(Icons::Help->value, 'How to get the value')
+            ->live();
+
+        $valueField = TextInput::make($key.'.value')
+            ->label('Value')
+            ->default($default)
+            ->hintIcon(Icons::Help->value, fn (Get $get) => ScraperStrategyType::getValueHelp($get($key.'.type')))
+            ->live();
+
+        if ($required) {
+            $typeField = $typeField->required();
+            $valueField = $valueField->required();
+        }
+
         return [
-            Select::make($key.'.type')
-                ->label('Type')
-                ->options(ScraperStrategyType::class)
-                ->required()
-                ->default(ScraperStrategyType::Selector->value)
-                ->hintIcon(Icons::Help->value, 'How to get the value')
-                ->live(),
-            TextInput::make($key.'.value')
-                ->label('Value')
-                ->default($default)
-                ->required()
-                ->hintIcon(Icons::Help->value, fn (Get $get) => ScraperStrategyType::getValueHelp($get($key.'.type')))
-                ->live(),
+            $typeField,
+            $valueField,
             TextInput::make($key.'.prepend')
                 ->label('Prepend')
                 ->hintIcon(Icons::Help->value, 'Optionally prepend a static value to the extracted value'),

--- a/app/Filament/Resources/ProductResource/Actions/AddUrlAction.php
+++ b/app/Filament/Resources/ProductResource/Actions/AddUrlAction.php
@@ -48,11 +48,17 @@ class AddUrlAction extends Action
             $product = $this->record;
 
             try {
-                Url::createFromUrl(
+                $urlModel = Url::createFromUrl(
                     url: $data['url'],
                     productId: $product->getKey(),
                     userId: auth()->id(),
                 );
+
+                if ($urlModel === false) {
+                    $this->failure();
+
+                    return;
+                }
 
                 $this->success();
                 $this->redirect($product->view_url);

--- a/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
+++ b/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\ProductResource;
 use App\Models\Url;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\ValidationException;
 
 class CreateProduct extends CreateRecord
 {
@@ -25,6 +26,12 @@ class CreateProduct extends CreateRecord
             userId: auth()->id(),
             createStore: data_get($data, 'create_store', false)
         );
+
+        if ($urlModel === false) {
+            throw ValidationException::withMessages([
+                'url' => __('Unable to create product from this URL'),
+            ]);
+        }
 
         return $urlModel->product;
     }

--- a/app/Filament/Resources/StoreResource.php
+++ b/app/Filament/Resources/StoreResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Enums\Icons;
 use App\Enums\ScraperService;
+use App\Enums\StockStatus;
 use App\Filament\Concerns\HasScraperTrait;
 use App\Filament\Pages\AppSettingsPage;
 use App\Filament\Resources\StoreResource\Pages\CreateStore;
@@ -17,6 +18,7 @@ use Filament\Forms;
 use Filament\Forms\Components\Section;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
+use Filament\Forms\Get;
 use Filament\Resources\Resource;
 use Filament\Support\Enums\FontWeight;
 use Filament\Tables\Actions\BulkActionGroup;
@@ -81,6 +83,43 @@ class StoreResource extends Resource
                     Forms\Components\Section::make('Image strategy')->schema([
                         Forms\Components\Group::make(self::makeStrategyInput('image', self::DEFAULT_SELECTORS['image']))->columns(2),
                     ])->description('How to get the product image'),
+                    Forms\Components\Section::make('Availability strategy')->schema([
+                        Forms\Components\Group::make(self::makeStrategyInput('availability', required: false))->columns(2),
+                        Forms\Components\Section::make('Match values')
+                            ->schema(
+                                collect(StockStatus::nonInStockCases())->map(
+                                    fn (StockStatus $status) => Forms\Components\Group::make([
+                                        Forms\Components\Select::make('availability.match.'.$status->value.'.type')
+                                            ->label('Type')
+                                            ->options([
+                                                'match' => 'Exact match',
+                                                'regex' => 'Regex',
+                                            ])
+                                            ->default('match')
+                                            ->afterStateHydrated(fn (Forms\Components\Select $component, ?string $state) => $component->state($state ?? 'match'))
+                                            ->required(),
+                                        TextInput::make('availability.match.'.$status->value.'.value')
+                                            ->label($status->getLabel())
+                                            ->hintIcon($status->getIcon(), 'If the scraped text matches this value, the product will be marked as "'.$status->getLabel().'"'),
+                                    ])->columns(2)
+                                )->toArray()
+                            )
+                            ->description('Map scraped text values to stock statuses. Order is priority (first match wins).')
+                            ->columns(1)
+                            ->collapsed(fn (Get $get): bool => empty(array_filter(
+                                (array) $get('availability.match'),
+                                fn ($entry, $key) => $key !== 'default' && (is_array($entry) ? ($entry['value'] ?? '') !== '' : ($entry !== '' && $entry !== null)),
+                                ARRAY_FILTER_USE_BOTH,
+                            ))),
+                        Forms\Components\Select::make('availability.match.default')
+                            ->label('Default status')
+                            ->options(StockStatus::class)
+                            ->default(StockStatus::InStock->value)
+                            ->afterStateHydrated(fn (Forms\Components\Select $component, ?string $state) => $component->state($state ?? StockStatus::InStock->value))
+                            ->required()
+                            ->hintIcon(Icons::Help->value, 'The status to use when the scraped text does not match any of the values above'),
+                    ])->description('Optional: a selector that matches product availability.')
+                        ->collapsed(fn (Get $get): bool => ($get('availability.value') ?? '') === ''),
                 ])
                     ->label('Scrape Strategy')
                     ->statePath('scrape_strategy'),

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -364,9 +364,11 @@ class Product extends Model
             $cache->filter(fn (PriceCacheDto $price) => $price->getUrlId() === $urlId);
         }
 
-        return round($cache->map(fn (PriceCacheDto $price) => $price->getHistory()->values()->toArray())
+        $values = $cache->map(fn (PriceCacheDto $price) => $price->getHistory()->values()->toArray())
             ->flatten()
-            ->{$method}(), 2);
+            ->filter(fn ($value) => $value > 0);
+
+        return $values->isEmpty() ? 0 : round($values->{$method}(), 2);
     }
 
     /**
@@ -394,7 +396,7 @@ class Product extends Model
             ->map(function ($url) use ($history): array {
                 /** @var Url $url */
                 /** @var Collection $urlHistory */
-                $urlHistory = $history->get($url->getKey(), collect([now()->toDateString() => 0]));
+                $urlHistory = $history->get($url->getKey(), collect());
                 /** @var Store $store */
                 $store = $url->store;
 
@@ -403,12 +405,14 @@ class Product extends Model
                 $lastScrapedPrice = $url->prices()->latest('id')->first();
                 $lastScrapedTimestamp = $lastScrapedPrice?->created_at;
 
-                // Build trend, current price vs average price.
-                $trend = Trend::calculateTrend(
-                    $urlHistory->last(),
-                    $urlHistory->values()->avg(),
-                    $urlHistory->values()->min(),
-                );
+                // Build trend, current price vs average price (skip for URLs with no history).
+                $trend = $urlHistory->isEmpty()
+                    ? Trend::None->value
+                    : Trend::calculateTrend(
+                        $urlHistory->last(),
+                        $urlHistory->values()->avg(),
+                        $urlHistory->values()->min(),
+                    );
 
                 // Build output suitable for dto.
                 return [
@@ -417,7 +421,7 @@ class Product extends Model
                     'url_id' => $url->getKey(),
                     'url' => $url->buy_url,
                     'trend' => $trend,
-                    'price' => $urlHistory->last(),
+                    'price' => $urlHistory->isEmpty() ? 0 : $urlHistory->last(),
                     'history' => $urlHistory->toArray(),
                     'last_scrape' => $lastScrapedTimestamp?->toDateTimeString(),
                     'locale' => $store->locale,

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -386,11 +386,11 @@ class Product extends Model
             ->with('store')
             ->get();
 
-        $urls = Url::findMany($history->keys())->merge($outOfStockUrls);
+        $urls = $this->urls()->whereIn('id', $history->keys())->with('store')->get()->merge($outOfStockUrls);
 
         return $urls
             ->filter(function ($url) {
-                // Filter out URLs without a store (e.g., during deletion)
+                /** @var Url $url */
                 return $url->store !== null;
             })
             ->map(function ($url) use ($history): array {

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -361,7 +361,7 @@ class Product extends Model
         $cache = $this->getPriceCache();
 
         if ($urlId) {
-            $cache->filter(fn (PriceCacheDto $price) => $price->getUrlId() === $urlId);
+            $cache = $cache->filter(fn (PriceCacheDto $price) => $price->getUrlId() === $urlId);
         }
 
         $values = $cache->map(fn (PriceCacheDto $price) => $price->getHistory()->values()->toArray())

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Dto\PriceCacheDto;
 use App\Enums\Statuses;
+use App\Enums\StockStatus;
 use App\Enums\Trend;
 use App\Filament\Actions\BaseAction;
 use App\Services\Helpers\CurrencyHelper;
@@ -344,7 +345,10 @@ class Product extends Model
     public function getPriceCache(): Collection
     {
         return collect($this->price_cache)
-            ->sortBy('price')
+            ->sortBy([
+                fn ($item) => StockStatus::fromScrapedValue($item['availability'] ?? null)->getSortOrder(),
+                ['price', 'asc'],
+            ])
             ->map(fn ($price) => PriceCacheDto::fromArray($price))
             ->values();
     }
@@ -371,7 +375,16 @@ class Product extends Model
     public function buildPriceCache(): Collection
     {
         $history = $this->getPriceHistory();
-        $urls = Url::findMany($history->keys());
+
+        // Include out-of-stock URLs that have no price history (e.g. price 0).
+        /** @var \Illuminate\Database\Eloquent\Collection<int, Url> $outOfStockUrls */
+        $outOfStockUrls = $this->urls()
+            ->whereNotNull('availability')
+            ->whereNotIn('id', $history->keys())
+            ->with('store')
+            ->get();
+
+        $urls = Url::findMany($history->keys())->merge($outOfStockUrls);
 
         return $urls
             ->filter(function ($url) {
@@ -381,7 +394,7 @@ class Product extends Model
             ->map(function ($url) use ($history): array {
                 /** @var Url $url */
                 /** @var Collection $urlHistory */
-                $urlHistory = $history->get($url->getKey());
+                $urlHistory = $history->get($url->getKey(), collect([now()->toDateString() => 0]));
                 /** @var Store $store */
                 $store = $url->store;
 
@@ -409,9 +422,13 @@ class Product extends Model
                     'last_scrape' => $lastScrapedTimestamp?->toDateTimeString(),
                     'locale' => $store->locale,
                     'currency' => $store->currency,
+                    'availability' => $url->availability,
                 ];
             })
-            ->sortBy('price')
+            ->sortBy([
+                fn ($item) => StockStatus::fromScrapedValue($item['availability'] ?? null)->getSortOrder(),
+                ['price', 'asc'],
+            ])
             ->values();
     }
 

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -162,7 +162,8 @@ class Url extends Model
         /** @var ?Store $store */
         $store = data_get($scrape, 'store');
 
-        $isUnavailable = ! empty(data_get($scrape, 'availability'));
+        $matchConfig = data_get($store, 'scrape_strategy.availability.match');
+        $isUnavailable = StockStatus::matchFromScrapedValue(data_get($scrape, 'availability'), $matchConfig)->isUnavailable();
 
         if (! $store || (! data_get($scrape, 'price') && ! $isUnavailable)) {
             return false;

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -162,9 +162,9 @@ class Url extends Model
         /** @var ?Store $store */
         $store = data_get($scrape, 'store');
 
-        $isOutOfStock = ! empty(data_get($scrape, 'availability'));
+        $isUnavailable = ! empty(data_get($scrape, 'availability'));
 
-        if (! $store || (! data_get($scrape, 'price') && ! $isOutOfStock)) {
+        if (! $store || (! data_get($scrape, 'price') && ! $isUnavailable)) {
             return false;
         }
 

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\StockStatus;
 use App\Services\AutoCreateStore;
 use App\Services\Helpers\AffiliateHelper;
 use App\Services\Helpers\CurrencyHelper;
@@ -54,6 +55,7 @@ class Url extends Model
         return [
             'updated_at' => 'datetime',
             'created_at' => 'datetime',
+            'availability' => 'string',
         ];
     }
 
@@ -160,7 +162,9 @@ class Url extends Model
         /** @var ?Store $store */
         $store = data_get($scrape, 'store');
 
-        if (! $store || ! data_get($scrape, 'price')) {
+        $isOutOfStock = ! empty(data_get($scrape, 'availability'));
+
+        if (! $store || (! data_get($scrape, 'price') && ! $isOutOfStock)) {
             return false;
         }
 
@@ -186,19 +190,36 @@ class Url extends Model
             'product_id' => $productId,
         ]);
 
-        $urlModel->updatePrice(data_get($scrape, 'price'));
+        $urlModel->updatePrice(data_get($scrape, 'price'), $scrape);
 
         return $urlModel;
     }
 
-    public function updatePrice(int|float|string|null $price = null): Price|Model|null
+    public function updatePrice(int|float|string|null $price = null, ?array $scrapeResult = null): Price|Model|null
     {
         if (! $this->store_id) {
             return null;
         }
 
         if (is_null($price) || $price === '') {
-            $price = data_get($this->scrape(), 'price');
+            $scrapeResult = $scrapeResult ?? $this->scrape();
+            $price = data_get($scrapeResult, 'price');
+        }
+
+        // Update out-of-stock status based on scrape result.
+        if ($scrapeResult) {
+            $scrapedValue = data_get($scrapeResult, 'availability');
+            $matchConfig = data_get($this->store, 'scrape_strategy.availability.match');
+            $stockStatus = StockStatus::matchFromScrapedValue($scrapedValue, $matchConfig);
+            $this->availability = $stockStatus->isUnavailable() ? $stockStatus->value : null;
+            $this->save();
+
+            // If unavailable and no price scraped, use the most recent price or 0.
+            if ($stockStatus->isUnavailable() && (is_null($price) || $price === '')) {
+                /** @var ?Price $latestPrice */
+                $latestPrice = $this->prices()->first();
+                $price = $latestPrice !== null ? $latestPrice->price : 0;
+            }
         }
 
         if (is_null($price) || $price === '') {

--- a/app/Rules/StoreUrl.php
+++ b/app/Rules/StoreUrl.php
@@ -25,9 +25,9 @@ class StoreUrl implements DataAwareRule, ValidationRule
         if ($store) {
             $scrape = ScrapeUrl::new($value)->scrape();
 
-            $isOutOfStock = ! empty($scrape['availability']);
+            $isUnavailable = ! empty($scrape['availability']);
 
-            if (empty($scrape['title']) || (empty($scrape['price']) && ! $isOutOfStock)) {
+            if (empty($scrape['title']) || (empty($scrape['price']) && ! $isUnavailable)) {
                 $fail('The url does not contain a valid title or price');
             }
         } elseif ($shouldCreateStore && ! AutoCreateStore::canAutoCreateFromUrl($value)) {

--- a/app/Rules/StoreUrl.php
+++ b/app/Rules/StoreUrl.php
@@ -2,6 +2,7 @@
 
 namespace App\Rules;
 
+use App\Enums\StockStatus;
 use App\Services\AutoCreateStore;
 use App\Services\ScrapeUrl;
 use Closure;
@@ -25,7 +26,8 @@ class StoreUrl implements DataAwareRule, ValidationRule
         if ($store) {
             $scrape = ScrapeUrl::new($value)->scrape();
 
-            $isUnavailable = ! empty($scrape['availability']);
+            $matchConfig = data_get($scrape, 'store.scrape_strategy.availability.match');
+            $isUnavailable = StockStatus::matchFromScrapedValue($scrape['availability'] ?? null, $matchConfig)->isUnavailable();
 
             if (empty($scrape['title']) || (empty($scrape['price']) && ! $isUnavailable)) {
                 $fail('The url does not contain a valid title or price');

--- a/app/Rules/StoreUrl.php
+++ b/app/Rules/StoreUrl.php
@@ -25,7 +25,9 @@ class StoreUrl implements DataAwareRule, ValidationRule
         if ($store) {
             $scrape = ScrapeUrl::new($value)->scrape();
 
-            if (empty($scrape['title']) || empty($scrape['price'])) {
+            $isOutOfStock = ! empty($scrape['availability']);
+
+            if (empty($scrape['title']) || (empty($scrape['price']) && ! $isOutOfStock)) {
                 $fail('The url does not contain a valid title or price');
             }
         } elseif ($shouldCreateStore && ! AutoCreateStore::canAutoCreateFromUrl($value)) {

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -3,6 +3,7 @@
 namespace App\Services;
 
 use App\Enums\ScraperService;
+use App\Enums\StockStatus;
 use App\Models\Store;
 use App\Services\Helpers\SettingsHelper;
 use App\Settings\AppSettings;
@@ -129,7 +130,8 @@ class ScrapeUrl
             }
         }
 
-        $isUnavailable = ! empty($output['availability']);
+        $matchConfig = data_get($output, 'store.scrape_strategy.availability.match');
+        $isUnavailable = StockStatus::matchFromScrapedValue($output['availability'] ?? null, $matchConfig)->isUnavailable();
 
         foreach (['price', 'title'] as $required) {
             // Skip price requirement when product is unavailable.

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -45,6 +45,7 @@ class ScrapeUrl
         'description',
         'price',
         'image',
+        'availability',
     ];
 
     public bool $sendUiNotifications = true;
@@ -128,7 +129,14 @@ class ScrapeUrl
             }
         }
 
+        $isOutOfStock = ! empty($output['availability']);
+
         foreach (['price', 'title'] as $required) {
+            // Skip price requirement when product is out of stock.
+            if ($required === 'price' && $isOutOfStock) {
+                continue;
+            }
+
             if (empty($output[$required])) {
                 $this->errorLog('Error scraping URL '.$attempt.' times', [
                     'attempts' => $attempt,

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -129,11 +129,11 @@ class ScrapeUrl
             }
         }
 
-        $isOutOfStock = ! empty($output['availability']);
+        $isUnavailable = ! empty($output['availability']);
 
         foreach (['price', 'title'] as $required) {
-            // Skip price requirement when product is out of stock.
-            if ($required === 'price' && $isOutOfStock) {
+            // Skip price requirement when product is unavailable.
+            if ($required === 'price' && $isUnavailable) {
                 continue;
             }
 

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -37,15 +37,16 @@ class ProductFactory extends Factory
         ];
     }
 
-    public function addUrlWithPrices(string $url, array $prices): self
+    public function addUrlWithPrices(string $url, array $prices, ?string $availability = null): self
     {
-        return $this->afterCreating(function (Product $product) use ($url, $prices) {
+        return $this->afterCreating(function (Product $product) use ($url, $prices, $availability) {
             $store = ScrapeUrl::new($url)->getStore() ?? Store::factory()->forUrl($url)->createOne();
 
             /** @var Url $url */
             $url = $product->urls()->create([
                 'url' => $url,
                 'store_id' => $store->id,
+                'availability' => $availability,
             ]);
 
             foreach ($prices as $idx => $price) {

--- a/database/migrations/2026_02_21_000000_add_availability_to_urls_table.php
+++ b/database/migrations/2026_02_21_000000_add_availability_to_urls_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('urls', function (Blueprint $table) {
+            $table->string('availability')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('urls', function (Blueprint $table) {
+            $table->dropColumn('availability');
+        });
+    }
+};

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -56,6 +56,7 @@ class ProductSeeder extends Seeder
             'urls' => [
                 'https://www.woolworths.com.au/shop/productdetails/618643/finish-ultimate-lemon-dishwasher-tablets' => ['24', '24', '22', '23', '24'],
                 'https://www.coles.com.au/product/finish-ultimate-dishwashing-tablets-lemon-sparkle-34-pack-7752503' => ['22', '22', '21', '21', '22'],
+                'https://www.woolworths.com.au/shop/productdetails/78637/finish-ultimate-lemon-dishwasher-tablets' => ['30', '30', '28', '29', '30'],
                 'https://www.woolworths.com.au/shop/productdetails/148368/finish-ultimate-lemon-dishwasher-tablets' => ['39', '39', '37', '38', '39'],
                 'https://www.coles.com.au/product/finish-ultimate-dishwasher-tablets-lemon-46-pack-3967235' => ['35', '35', '33', '34', '35'],
             ],

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -66,7 +66,7 @@ class ProductSeeder extends Seeder
         [
             'title' => 'Ubiquiti UniFi Protect Camera G6 180 (Black)',
             'urls' => [
-                'https://thetechgeeks.com/products/uvc-g6-180-b' => ['prices' => ['731.50'], 'availability' => 'Special Order'],
+                'https://thetechgeeks.com/products/uvc-g6-180-b' => ['prices' => ['731.50'], 'availability' => 'special_order'],
             ],
             'image' => 'https://thetechgeeks.com/cdn/shop/files/UVC-G6-180-B_grande.png',
             'tag' => 'Tech',
@@ -74,7 +74,7 @@ class ProductSeeder extends Seeder
         [
             'title' => 'Ubiquiti UniFi Travel Router',
             'urls' => [
-                'https://thetechgeeks.com/products/utr' => ['prices' => ['225.50'], 'availability' => 'Special Order'],
+                'https://thetechgeeks.com/products/utr' => ['prices' => ['225.50'], 'availability' => 'special_order'],
             ],
             'image' => 'https://thetechgeeks.com/cdn/shop/files/UTR_grande.png',
             'tag' => 'Tech',
@@ -82,7 +82,7 @@ class ProductSeeder extends Seeder
         [
             'title' => 'Ubiquiti UniFi Edge AI Appliance',
             'urls' => [
-                'https://thetechgeeks.com/products/ai-key' => ['prices' => ['1815'], 'availability' => 'Back Order'],
+                'https://thetechgeeks.com/products/ai-key' => ['prices' => ['1815'], 'availability' => 'back_order'],
             ],
             'image' => 'https://thetechgeeks.com/cdn/shop/files/AI-Key_grande.png',
             'tag' => 'Tech',
@@ -90,7 +90,7 @@ class ProductSeeder extends Seeder
         [
             'title' => 'Ubiquiti Pro Max 16 Rack Mount Kit',
             'urls' => [
-                'https://thetechgeeks.com/products/uacc-pro-max-16-rm' => ['prices' => ['126.50'], 'availability' => 'Pre-Order Now'],
+                'https://thetechgeeks.com/products/uacc-pro-max-16-rm' => ['prices' => ['126.50'], 'availability' => 'pre_order'],
             ],
             'image' => 'https://thetechgeeks.com/cdn/shop/files/UACC-Pro-Max-16-RM_grande.png',
             'tag' => 'Tech',

--- a/database/seeders/ProductSeeder.php
+++ b/database/seeders/ProductSeeder.php
@@ -51,6 +51,49 @@ class ProductSeeder extends Seeder
             'image' => 'https://m.media-amazon.com/images/I/812-y3MIhmL._AC_SX679_PIbundle-2,TopRight,0,0_SH20_.jpg',
             'tag' => 'Household',
         ],
+        [
+            'title' => 'Finish Ultimate Lemon Dishwasher Tablets',
+            'urls' => [
+                'https://www.woolworths.com.au/shop/productdetails/618643/finish-ultimate-lemon-dishwasher-tablets' => ['24', '24', '22', '23', '24'],
+                'https://www.coles.com.au/product/finish-ultimate-dishwashing-tablets-lemon-sparkle-34-pack-7752503' => ['22', '22', '21', '21', '22'],
+                'https://www.woolworths.com.au/shop/productdetails/148368/finish-ultimate-lemon-dishwasher-tablets' => ['39', '39', '37', '38', '39'],
+                'https://www.coles.com.au/product/finish-ultimate-dishwasher-tablets-lemon-46-pack-3967235' => ['35', '35', '33', '34', '35'],
+            ],
+            'image' => 'https://assets.woolworths.com.au/images/1005/618643.jpg?impolicy=wowsmkqiema&w=600&h=600',
+            'tag' => 'Household',
+        ],
+        [
+            'title' => 'Ubiquiti UniFi Protect Camera G6 180 (Black)',
+            'urls' => [
+                'https://thetechgeeks.com/products/uvc-g6-180-b' => ['prices' => ['731.50'], 'availability' => 'Special Order'],
+            ],
+            'image' => 'https://thetechgeeks.com/cdn/shop/files/UVC-G6-180-B_grande.png',
+            'tag' => 'Tech',
+        ],
+        [
+            'title' => 'Ubiquiti UniFi Travel Router',
+            'urls' => [
+                'https://thetechgeeks.com/products/utr' => ['prices' => ['225.50'], 'availability' => 'Special Order'],
+            ],
+            'image' => 'https://thetechgeeks.com/cdn/shop/files/UTR_grande.png',
+            'tag' => 'Tech',
+        ],
+        [
+            'title' => 'Ubiquiti UniFi Edge AI Appliance',
+            'urls' => [
+                'https://thetechgeeks.com/products/ai-key' => ['prices' => ['1815'], 'availability' => 'Back Order'],
+            ],
+            'image' => 'https://thetechgeeks.com/cdn/shop/files/AI-Key_grande.png',
+            'tag' => 'Tech',
+        ],
+        [
+            'title' => 'Ubiquiti Pro Max 16 Rack Mount Kit',
+            'urls' => [
+                'https://thetechgeeks.com/products/uacc-pro-max-16-rm' => ['prices' => ['126.50'], 'availability' => 'Pre-Order Now'],
+            ],
+            'image' => 'https://thetechgeeks.com/cdn/shop/files/UACC-Pro-Max-16-RM_grande.png',
+            'tag' => 'Tech',
+        ],
     ];
 
     /**
@@ -88,8 +131,13 @@ class ProductSeeder extends Seeder
         foreach ($this->dummy as $productData) {
             $factory = Product::factory();
 
-            foreach ($productData['urls'] as $url => $prices) {
-                $factory = $factory->addUrlWithPrices($url, $prices);
+            foreach ($productData['urls'] as $url => $urlData) {
+                // Support both simple ['price1', 'price2'] and extended ['prices' => [...], 'availability' => '...'] formats.
+                if (is_array($urlData) && array_key_exists('prices', $urlData)) {
+                    $factory = $factory->addUrlWithPrices($url, $urlData['prices'], $urlData['availability'] ?? null);
+                } else {
+                    $factory = $factory->addUrlWithPrices($url, $urlData);
+                }
             }
 
             /** @var Product $product */

--- a/database/seeders/Stores/australia.php
+++ b/database/seeders/Stores/australia.php
@@ -238,6 +238,17 @@ return [
                 'value' => 'meta[property=og:image]|content',
                 'type' => 'selector',
             ],
+            'availability' => [
+                'value' => '~"availability":"https?://schema.org/(\w+)"~',
+                'type' => 'regex',
+                'match' => [
+                    'out_of_stock' => ['type' => 'match', 'value' => 'OutOfStock'],
+                    'pre_order' => ['type' => 'match', 'value' => 'PreOrder'],
+                    'discontinued' => ['type' => 'match', 'value' => 'Discontinued'],
+                    'back_order' => ['type' => 'match', 'value' => 'BackOrder'],
+                    'default' => 'in_stock',
+                ],
+            ],
         ],
         'user_id' => 1,
     ],
@@ -255,12 +266,23 @@ return [
                 'type' => 'selector',
             ],
             'price' => [
-                'value' => '.price-parts',
-                'type' => 'selector',
+                'value' => '~"price":(\d+\.?\d*),"priceCurrency":"AUD"~',
+                'type' => 'regex',
             ],
             'image' => [
-                'value' => 'meta[property=og:image]|content',
-                'type' => 'selector',
+                'value' => '~"image":"(https://cdn0\.woolworths\.media/content/wowproductimages/large/[^"]+)"~',
+                'type' => 'regex',
+            ],
+            'availability' => [
+                'value' => '~"availability":"https?://schema.org/(\w+)"~',
+                'type' => 'regex',
+                'match' => [
+                    'out_of_stock' => ['type' => 'match', 'value' => 'OutOfStock'],
+                    'pre_order' => ['type' => 'match', 'value' => 'PreOrder'],
+                    'discontinued' => ['type' => 'match', 'value' => 'Discontinued'],
+                    'back_order' => ['type' => 'match', 'value' => 'BackOrder'],
+                    'default' => 'in_stock',
+                ],
             ],
         ],
         'settings' => [
@@ -288,6 +310,46 @@ return [
             'image' => [
                 'value' => '.img|src',
                 'type' => 'selector',
+            ],
+        ],
+        'settings' => [
+            'scraper_service' => ScraperService::Api->value,
+            'scraper_service_settings' => '',
+        ],
+    ],
+
+    // Tech.
+    [
+        'name' => 'The Tech Geeks',
+        'initials' => 'TG',
+        'slug' => 'the-tech-geeks',
+        'domains' => [
+            ['domain' => 'thetechgeeks.com'],
+            ['domain' => 'www.thetechgeeks.com'],
+        ],
+        'scrape_strategy' => [
+            'title' => [
+                'value' => 'meta[property=og:title]|content',
+                'type' => 'selector',
+            ],
+            'price' => [
+                'value' => 'meta[property=og:price:amount]|content',
+                'type' => 'selector',
+            ],
+            'image' => [
+                'value' => 'meta[property=og:image]|content',
+                'type' => 'selector',
+            ],
+            'availability' => [
+                'value' => 'button[name="add"]|value',
+                'type' => 'selector',
+                'match' => [
+                    'pre_order' => ['type' => 'regex', 'value' => 'Pre.?Order'],
+                    'special_order' => ['type' => 'regex', 'value' => 'Special.?Order'],
+                    'back_order' => ['type' => 'regex', 'value' => 'Back.?Order'],
+                    'out_of_stock' => ['type' => 'match', 'value' => 'Sold out'],
+                    'default' => 'in_stock',
+                ],
             ],
         ],
         'settings' => [

--- a/resources/views/components/prices-column.blade.php
+++ b/resources/views/components/prices-column.blade.php
@@ -43,7 +43,7 @@
                     <div class="hover:underline {{ $color }}" @if ($idx > 0) style="{{ Filament\Support\get_color_css_variables(Color::Gray, shades: [300, 500, 400, 600, 800]) }}" @endif>
                         <strong class="text-[1.2em] font-bold">{{ $cache->getPriceFormatted() }}</strong>
                         ({{ $cache->getStoreName() }})
-                        @if ($cache->isOutOfStock())
+                        @if ($cache->isUnavailable())
                             <span style="{{ Filament\Support\get_color_css_variables($cache->getStockStatusColor(), shades: [400, 500]) }}" class="text-xs text-custom-500 dark:text-custom-400 font-medium ml-1">{{ __($cache->getStockStatusLabel()) }}</span>
                         @endif
                     </div>

--- a/resources/views/components/prices-column.blade.php
+++ b/resources/views/components/prices-column.blade.php
@@ -43,6 +43,9 @@
                     <div class="hover:underline {{ $color }}" @if ($idx > 0) style="{{ Filament\Support\get_color_css_variables(Color::Gray, shades: [300, 500, 400, 600, 800]) }}" @endif>
                         <strong class="text-[1.2em] font-bold">{{ $cache->getPriceFormatted() }}</strong>
                         ({{ $cache->getStoreName() }})
+                        @if ($cache->isOutOfStock())
+                            <span style="{{ Filament\Support\get_color_css_variables($cache->getStockStatusColor(), shades: [400, 500]) }}" class="text-xs text-custom-500 dark:text-custom-400 font-medium ml-1">{{ __($cache->getStockStatusLabel()) }}</span>
+                        @endif
                     </div>
 
                 </a>

--- a/resources/views/components/product-card.blade.php
+++ b/resources/views/components/product-card.blade.php
@@ -37,7 +37,7 @@
                         <span class="text-xs text-gray-500 dark:text-gray-400 font-bold display-block">
                             {{ '@'.$latestPrice->getStoreName() }}
                         </span>
-                        @if ($latestPrice->isOutOfStock())
+                        @if ($latestPrice->isUnavailable())
                             <div class="block mt-1">
                                 @include('components.icon-badge', [
                                     'hoverText' => __('This item is currently :status', ['status' => strtolower($latestPrice->getStockStatusLabel())]),

--- a/resources/views/components/product-card.blade.php
+++ b/resources/views/components/product-card.blade.php
@@ -37,6 +37,16 @@
                         <span class="text-xs text-gray-500 dark:text-gray-400 font-bold display-block">
                             {{ '@'.$latestPrice->getStoreName() }}
                         </span>
+                        @if ($latestPrice->isOutOfStock())
+                            <div class="block mt-1">
+                                @include('components.icon-badge', [
+                                    'hoverText' => __('This item is currently :status', ['status' => strtolower($latestPrice->getStockStatusLabel())]),
+                                    'label' => __($latestPrice->getStockStatusLabel()),
+                                    'color' => $latestPrice->getStockStatusColor(),
+                                    'icon' => $latestPrice->getStockStatusIcon(),
+                                ])
+                            </div>
+                        @endif
                         <div class="block mb-2">
                             @include('components.product-badges', ['product' => $product])
                         </div>

--- a/resources/views/filament/pages/product/price-stat.blade.php
+++ b/resources/views/filament/pages/product/price-stat.blade.php
@@ -98,9 +98,9 @@
         @endif
     </div>
 
-    @if ($priceCache->isOutOfStock() || ! $priceCache->isLastScrapeSuccessful() || $priceCache->matchesNotification($product))
+    @if ($priceCache->isUnavailable() || ! $priceCache->isLastScrapeSuccessful() || $priceCache->matchesNotification($product))
         <div class="mt-2 pb-4 inline-flex gap-2">
-            @if ($priceCache->isOutOfStock())
+            @if ($priceCache->isUnavailable())
                 <div class="mb-2">
                     @include('components.icon-badge', [
                         'hoverText' => __('This item is currently :status', ['status' => strtolower($priceCache->getStockStatusLabel())]),

--- a/resources/views/filament/pages/product/price-stat.blade.php
+++ b/resources/views/filament/pages/product/price-stat.blade.php
@@ -98,8 +98,19 @@
         @endif
     </div>
 
-    @if (! $priceCache->isLastScrapeSuccessful() || $priceCache->matchesNotification($product))
+    @if ($priceCache->isOutOfStock() || ! $priceCache->isLastScrapeSuccessful() || $priceCache->matchesNotification($product))
         <div class="mt-2 pb-4 inline-flex gap-2">
+            @if ($priceCache->isOutOfStock())
+                <div class="mb-2">
+                    @include('components.icon-badge', [
+                        'hoverText' => __('This item is currently :status', ['status' => strtolower($priceCache->getStockStatusLabel())]),
+                        'label' => __($priceCache->getStockStatusLabel()),
+                        'color' => $priceCache->getStockStatusColor(),
+                        'icon' => $priceCache->getStockStatusIcon(),
+                    ])
+                </div>
+            @endif
+
             @if (! $priceCache->isLastScrapeSuccessful())
                 <div class="mb-2">
                     @include('components.icon-badge', [

--- a/resources/views/filament/resources/store-resource/widgets/test-results-widget.blade.php
+++ b/resources/views/filament/resources/store-resource/widgets/test-results-widget.blade.php
@@ -5,9 +5,40 @@
         @foreach($scrape as $key => $val)
             @if ($key !== 'store')
                 <div class="mb-8">
-                    <x-filament::section :heading="$key">
+                    <x-filament::section :heading="str_replace('_', ' ', ucfirst($key))">
                         <code class="block whitespace-pre overflow-x-auto">{{ is_string($val) ? $val : json_encode($val, JSON_PRETTY_PRINT) }}</code>
                     </x-filament::section>
+                    @if ($key === 'availability')
+                        @php
+                            $matchConfig = data_get($record, 'scrape_strategy.availability.match');
+                            $resolvedStatus = \App\Enums\StockStatus::matchFromScrapedValue($val, $matchConfig);
+
+                            $matchedRule = null;
+                            if (is_array($matchConfig)) {
+                                foreach ($matchConfig as $statusValue => $matchEntry) {
+                                    if ($statusValue === 'default' || $matchEntry === '' || $matchEntry === null) {
+                                        continue;
+                                    }
+                                    if (is_array($matchEntry)) {
+                                        $matchValue = $matchEntry['value'] ?? '';
+                                        $matchType = $matchEntry['type'] ?? 'match';
+                                        if ($matchValue !== '' && \App\Enums\StockStatus::tryFrom($statusValue)?->value === $resolvedStatus->value) {
+                                            $matchedRule = $matchType === 'regex' ? "regex \"$matchValue\"" : "exact \"$matchValue\"";
+                                            break;
+                                        }
+                                    } elseif (is_string($matchEntry) && trim($val) === trim($matchEntry)) {
+                                        $matchedRule = "exact \"$matchEntry\"";
+                                        break;
+                                    }
+                                }
+                            }
+                        @endphp
+                        <div class="mt-8">
+                            <x-filament::section heading="Product status">
+                                <code class="block whitespace-pre overflow-x-auto">{{ $resolvedStatus->getLabel() }}@if ($matchedRule) — matched {{ $matchedRule }}@elseif ($resolvedStatus === \App\Enums\StockStatus::InStock) — no match (default)@endif</code>
+                            </x-filament::section>
+                        </div>
+                    @endif
                 </div>
             @endif
         @endforeach

--- a/resources/views/tests/product-page.blade.php
+++ b/resources/views/tests/product-page.blade.php
@@ -18,5 +18,8 @@
 </head>
 <body>
     <p>This page is used for test responses</p>
+    @if (!empty($availability))
+        <span class="availability">{{ $availability }}</span>
+    @endif
 </body>
 </html>

--- a/tests/Feature/Models/ProductTest.php
+++ b/tests/Feature/Models/ProductTest.php
@@ -373,6 +373,58 @@ class ProductTest extends TestCase
         $this->assertNull($product->image);
     }
 
+    public function test_build_price_cache_includes_availability()
+    {
+        Carbon::setTestNow(Carbon::create(2025, 1, 10));
+        $product = $this->createOneProductWithUrlAndPrices(prices: [10, 20, 30]);
+
+        $priceCache = $product->buildPriceCache();
+        $first = $priceCache->first();
+
+        $this->assertArrayHasKey('availability', $first);
+        $this->assertNull($first['availability']);
+    }
+
+    public function test_build_price_cache_sorts_in_stock_before_unavailable()
+    {
+        Carbon::setTestNow(Carbon::create(2025, 1, 10));
+        $product = $this->createOneProductWithUrlAndPrices(prices: [50, 60, 70]);
+
+        // Create a second URL that is out of stock with a lower price.
+        $oosUrl = Url::factory()->withPrices([5, 10, 15])->createOne([
+            'product_id' => $product->getKey(),
+            'url' => 'https://example-oos.com',
+            'availability' => 'OutOfStock',
+        ]);
+
+        $priceCache = $product->buildPriceCache();
+
+        // The in-stock URL (higher price) should come first.
+        $this->assertNull($priceCache->first()['availability']);
+        $this->assertSame('OutOfStock', $priceCache->last()['availability']);
+    }
+
+    public function test_get_price_cache_sorts_in_stock_before_unavailable()
+    {
+        $product = Product::factory()->createOne([
+            'price_cache' => [
+                ['price' => 5, 'history' => [], 'availability' => 'OutOfStock'],
+                ['price' => 20, 'history' => [], 'availability' => null],
+                ['price' => 10, 'history' => [], 'availability' => null],
+            ],
+        ]);
+
+        $priceCache = $product->getPriceCache();
+
+        // In-stock items sorted by price first, then OOS items.
+        $this->assertFalse($priceCache->get(0)->isOutOfStock());
+        $this->assertEquals(10.0, $priceCache->get(0)->getPrice());
+        $this->assertFalse($priceCache->get(1)->isOutOfStock());
+        $this->assertEquals(20.0, $priceCache->get(1)->getPrice());
+        $this->assertTrue($priceCache->get(2)->isOutOfStock());
+        $this->assertEquals(5.0, $priceCache->get(2)->getPrice());
+    }
+
     protected function createOneProductWithUrlAndPrices(string $url = self::DEFAULT_URL, array $prices = [10, 15, 20], array $attrs = []): Product
     {
         return Product::factory()

--- a/tests/Feature/Models/ProductTest.php
+++ b/tests/Feature/Models/ProductTest.php
@@ -391,7 +391,7 @@ class ProductTest extends TestCase
         $product = $this->createOneProductWithUrlAndPrices(prices: [50, 60, 70]);
 
         // Create a second URL that is out of stock with a lower price.
-        $oosUrl = Url::factory()->withPrices([5, 10, 15])->createOne([
+        Url::factory()->withPrices([5, 10, 15])->createOne([
             'product_id' => $product->getKey(),
             'url' => 'https://example-oos.com',
             'availability' => 'OutOfStock',

--- a/tests/Feature/Models/ProductTest.php
+++ b/tests/Feature/Models/ProductTest.php
@@ -417,11 +417,11 @@ class ProductTest extends TestCase
         $priceCache = $product->getPriceCache();
 
         // In-stock items sorted by price first, then OOS items.
-        $this->assertFalse($priceCache->get(0)->isOutOfStock());
+        $this->assertFalse($priceCache->get(0)->isUnavailable());
         $this->assertEquals(10.0, $priceCache->get(0)->getPrice());
-        $this->assertFalse($priceCache->get(1)->isOutOfStock());
+        $this->assertFalse($priceCache->get(1)->isUnavailable());
         $this->assertEquals(20.0, $priceCache->get(1)->getPrice());
-        $this->assertTrue($priceCache->get(2)->isOutOfStock());
+        $this->assertTrue($priceCache->get(2)->isUnavailable());
         $this->assertEquals(5.0, $priceCache->get(2)->getPrice());
     }
 

--- a/tests/Feature/Models/UrlTest.php
+++ b/tests/Feature/Models/UrlTest.php
@@ -105,6 +105,64 @@ class UrlTest extends TestCase
         $this->assertNull($priceModel);
     }
 
+    public function test_create_from_url_with_unavailable_product_and_no_price()
+    {
+        $this->actingAs($this->user);
+
+        $this->store->update([
+            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+                'availability' => [
+                    'type' => 'selector',
+                    'value' => '.availability',
+                    'match' => [
+                        'out_of_stock' => ['type' => 'match', 'value' => 'OutOfStock'],
+                        'default' => 'in_stock',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $this->mockScrape('', 'Out of Stock Product', null, 'OutOfStock');
+
+        $urlModel = Url::createFromUrl(self::TEST_URL);
+
+        $this->assertInstanceOf(Url::class, $urlModel);
+        $this->assertEquals('out_of_stock', $urlModel->availability);
+        $this->assertEquals('Out of Stock Product', $urlModel->product->title);
+        $this->assertEquals(0, $urlModel->prices()->first()->price);
+    }
+
+    public function test_update_price_unavailable_no_price_uses_zero()
+    {
+        $product = Product::factory()->create();
+        $url = Url::factory()->createOne([
+            'url' => self::TEST_URL,
+            'product_id' => $product->id,
+            'store_id' => $this->store->id,
+        ]);
+
+        $this->store->update([
+            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+                'availability' => [
+                    'type' => 'selector',
+                    'value' => '.availability',
+                    'match' => [
+                        'out_of_stock' => ['type' => 'match', 'value' => 'OutOfStock'],
+                        'default' => 'in_stock',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $this->mockScrape('', 'foo', null, 'OutOfStock');
+
+        $priceModel = $url->updatePrice();
+
+        $this->assertInstanceOf(Price::class, $priceModel);
+        $this->assertEquals(0, $priceModel->price);
+        $this->assertEquals('out_of_stock', $url->fresh()->availability);
+    }
+
     public function test_product_name_short_returns_correct_value()
     {
         $product = Product::factory()->create(['title' => 'A long title that is too long, it should be trimmed to a limit so not so long']);

--- a/tests/Traits/ScraperTrait.php
+++ b/tests/Traits/ScraperTrait.php
@@ -7,13 +7,14 @@ use Illuminate\Support\Facades\View;
 
 trait ScraperTrait
 {
-    protected function mockScrape(mixed $price, mixed $title = null, mixed $image = null): void
+    protected function mockScrape(mixed $price, mixed $title = null, mixed $image = null, mixed $availability = null): void
     {
         Http::fake([
             '*' => Http::response(View::make('tests.product-page', [
                 'price' => $price,
                 'title' => $title,
                 'image' => $image,
+                'availability' => $availability,
             ])->render()),
         ]);
     }

--- a/tests/Unit/Dto/PriceCacheDtoTest.php
+++ b/tests/Unit/Dto/PriceCacheDtoTest.php
@@ -13,7 +13,7 @@ class PriceCacheDtoTest extends TestCase
     {
         $dto = new PriceCacheDto(price: 10.0);
 
-        $this->assertFalse($dto->isOutOfStock());
+        $this->assertFalse($dto->isUnavailable());
         $this->assertSame(StockStatus::InStock, $dto->getStockStatus());
     }
 
@@ -21,7 +21,7 @@ class PriceCacheDtoTest extends TestCase
     {
         $dto = new PriceCacheDto(price: 10.0, availability: 'OutOfStock');
 
-        $this->assertTrue($dto->isOutOfStock());
+        $this->assertTrue($dto->isUnavailable());
         $this->assertSame(StockStatus::OutOfStock, $dto->getStockStatus());
     }
 
@@ -33,7 +33,7 @@ class PriceCacheDtoTest extends TestCase
             'availability' => 'OutOfStock',
         ]);
 
-        $this->assertTrue($dto->isOutOfStock());
+        $this->assertTrue($dto->isUnavailable());
         $this->assertSame(StockStatus::OutOfStock, $dto->getStockStatus());
     }
 
@@ -44,7 +44,7 @@ class PriceCacheDtoTest extends TestCase
             'history' => [],
         ]);
 
-        $this->assertFalse($dto->isOutOfStock());
+        $this->assertFalse($dto->isUnavailable());
         $this->assertSame(StockStatus::InStock, $dto->getStockStatus());
     }
 
@@ -84,7 +84,7 @@ class PriceCacheDtoTest extends TestCase
 
         $this->assertSame(StockStatus::OutOfStock->value, $array['availability']);
         $this->assertSame(25.0, $array['price']);
-        $this->assertTrue($dto->isOutOfStock());
+        $this->assertTrue($dto->isUnavailable());
     }
 
     public function test_stock_status_convenience_methods()
@@ -109,7 +109,7 @@ class PriceCacheDtoTest extends TestCase
     {
         $dto = new PriceCacheDto(price: 10.0, availability: 'PreOrder');
 
-        $this->assertTrue($dto->isOutOfStock());
+        $this->assertTrue($dto->isUnavailable());
         $this->assertSame(StockStatus::PreOrder, $dto->getStockStatus());
         $this->assertSame('Pre-Order', $dto->getStockStatusLabel());
         $this->assertSame('info', $dto->getStockStatusColor());
@@ -123,7 +123,7 @@ class PriceCacheDtoTest extends TestCase
             'availability' => StockStatus::OutOfStock->value,
         ]);
 
-        $this->assertTrue($dto->isOutOfStock());
+        $this->assertTrue($dto->isUnavailable());
         $this->assertSame(StockStatus::OutOfStock, $dto->getStockStatus());
     }
 }

--- a/tests/Unit/Dto/PriceCacheDtoTest.php
+++ b/tests/Unit/Dto/PriceCacheDtoTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Tests\Unit\Dto;
+
+use App\Dto\PriceCacheDto;
+use App\Enums\StockStatus;
+use App\Enums\Trend;
+use Tests\TestCase;
+
+class PriceCacheDtoTest extends TestCase
+{
+    public function test_availability_defaults_to_in_stock()
+    {
+        $dto = new PriceCacheDto(price: 10.0);
+
+        $this->assertFalse($dto->isOutOfStock());
+        $this->assertSame(StockStatus::InStock, $dto->getStockStatus());
+    }
+
+    public function test_availability_can_be_set_via_constructor()
+    {
+        $dto = new PriceCacheDto(price: 10.0, availability: 'OutOfStock');
+
+        $this->assertTrue($dto->isOutOfStock());
+        $this->assertSame(StockStatus::OutOfStock, $dto->getStockStatus());
+    }
+
+    public function test_from_array_includes_availability()
+    {
+        $dto = PriceCacheDto::fromArray([
+            'price' => 10.0,
+            'history' => [],
+            'availability' => 'OutOfStock',
+        ]);
+
+        $this->assertTrue($dto->isOutOfStock());
+        $this->assertSame(StockStatus::OutOfStock, $dto->getStockStatus());
+    }
+
+    public function test_from_array_defaults_availability_to_in_stock()
+    {
+        $dto = PriceCacheDto::fromArray([
+            'price' => 10.0,
+            'history' => [],
+        ]);
+
+        $this->assertFalse($dto->isOutOfStock());
+        $this->assertSame(StockStatus::InStock, $dto->getStockStatus());
+    }
+
+    public function test_to_array_includes_availability()
+    {
+        $dto = new PriceCacheDto(price: 10.0, availability: 'OutOfStock');
+        $array = $dto->toArray();
+
+        $this->assertArrayHasKey('availability', $array);
+        $this->assertSame(StockStatus::OutOfStock->value, $array['availability']);
+    }
+
+    public function test_to_array_availability_null_by_default()
+    {
+        $dto = new PriceCacheDto(price: 10.0);
+        $array = $dto->toArray();
+
+        $this->assertArrayHasKey('availability', $array);
+        $this->assertNull($array['availability']);
+    }
+
+    public function test_from_array_to_array_preserves_availability()
+    {
+        $data = [
+            'price' => 25.0,
+            'store_id' => 1,
+            'store_name' => 'Test Store',
+            'url_id' => 1,
+            'url' => 'https://example.com',
+            'trend' => Trend::None->value,
+            'history' => [10.0, 20.0, 25.0],
+            'availability' => 'OutOfStock',
+        ];
+
+        $dto = PriceCacheDto::fromArray($data);
+        $array = $dto->toArray();
+
+        $this->assertSame(StockStatus::OutOfStock->value, $array['availability']);
+        $this->assertSame(25.0, $array['price']);
+        $this->assertTrue($dto->isOutOfStock());
+    }
+
+    public function test_stock_status_convenience_methods()
+    {
+        $dto = new PriceCacheDto(price: 10.0, availability: 'OutOfStock');
+
+        $this->assertSame('Out of Stock', $dto->getStockStatusLabel());
+        $this->assertSame('danger', $dto->getStockStatusColor());
+        $this->assertSame('heroicon-m-x-circle', $dto->getStockStatusIcon());
+    }
+
+    public function test_stock_status_convenience_methods_for_in_stock()
+    {
+        $dto = new PriceCacheDto(price: 10.0);
+
+        $this->assertSame('In Stock', $dto->getStockStatusLabel());
+        $this->assertSame('success', $dto->getStockStatusColor());
+        $this->assertSame('heroicon-m-check-circle', $dto->getStockStatusIcon());
+    }
+
+    public function test_pre_order_scraped_value_maps_correctly()
+    {
+        $dto = new PriceCacheDto(price: 10.0, availability: 'PreOrder');
+
+        $this->assertTrue($dto->isOutOfStock());
+        $this->assertSame(StockStatus::PreOrder, $dto->getStockStatus());
+        $this->assertSame('Pre-Order', $dto->getStockStatusLabel());
+        $this->assertSame('info', $dto->getStockStatusColor());
+    }
+
+    public function test_from_array_with_enum_value_string()
+    {
+        $dto = PriceCacheDto::fromArray([
+            'price' => 10.0,
+            'history' => [],
+            'availability' => StockStatus::OutOfStock->value,
+        ]);
+
+        $this->assertTrue($dto->isOutOfStock());
+        $this->assertSame(StockStatus::OutOfStock, $dto->getStockStatus());
+    }
+}

--- a/tests/Unit/Enums/StockStatusTest.php
+++ b/tests/Unit/Enums/StockStatusTest.php
@@ -83,6 +83,7 @@ class StockStatusTest extends TestCase
 
     public function test_from_scraped_value_maps_known_values()
     {
+        $this->assertSame(StockStatus::InStock, StockStatus::fromScrapedValue('InStock'));
         $this->assertSame(StockStatus::OutOfStock, StockStatus::fromScrapedValue('OutOfStock'));
         $this->assertSame(StockStatus::PreOrder, StockStatus::fromScrapedValue('PreOrder'));
         $this->assertSame(StockStatus::BackOrder, StockStatus::fromScrapedValue('BackOrder'));

--- a/tests/Unit/Enums/StockStatusTest.php
+++ b/tests/Unit/Enums/StockStatusTest.php
@@ -1,0 +1,275 @@
+<?php
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\StockStatus;
+use Tests\TestCase;
+
+class StockStatusTest extends TestCase
+{
+    public function test_all_cases_have_correct_values()
+    {
+        $this->assertSame('in_stock', StockStatus::InStock->value);
+        $this->assertSame('pre_order', StockStatus::PreOrder->value);
+        $this->assertSame('back_order', StockStatus::BackOrder->value);
+        $this->assertSame('special_order', StockStatus::SpecialOrder->value);
+        $this->assertSame('out_of_stock', StockStatus::OutOfStock->value);
+        $this->assertSame('discontinued', StockStatus::Discontinued->value);
+    }
+
+    public function test_all_cases_have_labels()
+    {
+        $this->assertSame('In Stock', StockStatus::InStock->getLabel());
+        $this->assertSame('Pre-Order', StockStatus::PreOrder->getLabel());
+        $this->assertSame('Back Order', StockStatus::BackOrder->getLabel());
+        $this->assertSame('Special Order', StockStatus::SpecialOrder->getLabel());
+        $this->assertSame('Out of Stock', StockStatus::OutOfStock->getLabel());
+        $this->assertSame('Discontinued', StockStatus::Discontinued->getLabel());
+    }
+
+    public function test_all_cases_have_colors()
+    {
+        $this->assertSame('success', StockStatus::InStock->getColor());
+        $this->assertSame('info', StockStatus::PreOrder->getColor());
+        $this->assertSame('warning', StockStatus::BackOrder->getColor());
+        $this->assertSame('warning', StockStatus::SpecialOrder->getColor());
+        $this->assertSame('danger', StockStatus::OutOfStock->getColor());
+        $this->assertSame('gray', StockStatus::Discontinued->getColor());
+    }
+
+    public function test_all_cases_have_icons()
+    {
+        $this->assertSame('heroicon-m-check-circle', StockStatus::InStock->getIcon());
+        $this->assertSame('heroicon-m-clock', StockStatus::PreOrder->getIcon());
+        $this->assertSame('heroicon-m-arrow-path', StockStatus::BackOrder->getIcon());
+        $this->assertSame('heroicon-m-truck', StockStatus::SpecialOrder->getIcon());
+        $this->assertSame('heroicon-m-x-circle', StockStatus::OutOfStock->getIcon());
+        $this->assertSame('heroicon-m-archive-box-x-mark', StockStatus::Discontinued->getIcon());
+    }
+
+    public function test_all_cases_have_sort_orders()
+    {
+        $this->assertSame(0, StockStatus::InStock->getSortOrder());
+        $this->assertSame(1, StockStatus::PreOrder->getSortOrder());
+        $this->assertSame(2, StockStatus::BackOrder->getSortOrder());
+        $this->assertSame(3, StockStatus::SpecialOrder->getSortOrder());
+        $this->assertSame(4, StockStatus::OutOfStock->getSortOrder());
+        $this->assertSame(5, StockStatus::Discontinued->getSortOrder());
+    }
+
+    public function test_is_unavailable_returns_false_for_in_stock()
+    {
+        $this->assertFalse(StockStatus::InStock->isUnavailable());
+    }
+
+    public function test_is_unavailable_returns_true_for_all_other_cases()
+    {
+        $this->assertTrue(StockStatus::PreOrder->isUnavailable());
+        $this->assertTrue(StockStatus::BackOrder->isUnavailable());
+        $this->assertTrue(StockStatus::SpecialOrder->isUnavailable());
+        $this->assertTrue(StockStatus::OutOfStock->isUnavailable());
+        $this->assertTrue(StockStatus::Discontinued->isUnavailable());
+    }
+
+    public function test_from_scraped_value_null_returns_in_stock()
+    {
+        $this->assertSame(StockStatus::InStock, StockStatus::fromScrapedValue(null));
+    }
+
+    public function test_from_scraped_value_empty_string_returns_in_stock()
+    {
+        $this->assertSame(StockStatus::InStock, StockStatus::fromScrapedValue(''));
+    }
+
+    public function test_from_scraped_value_maps_known_values()
+    {
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::fromScrapedValue('OutOfStock'));
+        $this->assertSame(StockStatus::PreOrder, StockStatus::fromScrapedValue('PreOrder'));
+        $this->assertSame(StockStatus::BackOrder, StockStatus::fromScrapedValue('BackOrder'));
+        $this->assertSame(StockStatus::SpecialOrder, StockStatus::fromScrapedValue('SpecialOrder'));
+        $this->assertSame(StockStatus::Discontinued, StockStatus::fromScrapedValue('Discontinued'));
+    }
+
+    public function test_from_scraped_value_unknown_string_returns_out_of_stock()
+    {
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::fromScrapedValue('SomeUnknownValue'));
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::fromScrapedValue('sold out'));
+    }
+
+    public function test_from_scraped_value_handles_enum_value_strings()
+    {
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::fromScrapedValue('out_of_stock'));
+        $this->assertSame(StockStatus::PreOrder, StockStatus::fromScrapedValue('pre_order'));
+        $this->assertSame(StockStatus::BackOrder, StockStatus::fromScrapedValue('back_order'));
+        $this->assertSame(StockStatus::SpecialOrder, StockStatus::fromScrapedValue('special_order'));
+        $this->assertSame(StockStatus::Discontinued, StockStatus::fromScrapedValue('discontinued'));
+        $this->assertSame(StockStatus::InStock, StockStatus::fromScrapedValue('in_stock'));
+    }
+
+    public function test_sort_order_is_sequential()
+    {
+        $cases = StockStatus::cases();
+        $sortOrders = array_map(fn (StockStatus $case) => $case->getSortOrder(), $cases);
+
+        $this->assertSame([0, 1, 2, 3, 4, 5], $sortOrders);
+    }
+
+    public function test_match_from_scraped_value_null_returns_in_stock()
+    {
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue(null, null));
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('', null));
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue(null, 'OutOfStock'));
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('', ['out_of_stock' => 'OutOfStock']));
+    }
+
+    public function test_match_from_scraped_value_with_array_config()
+    {
+        $config = [
+            'out_of_stock' => 'OutOfStock',
+            'pre_order' => 'PreOrder',
+            'discontinued' => 'Discontinued',
+        ];
+
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('OutOfStock', $config));
+        $this->assertSame(StockStatus::PreOrder, StockStatus::matchFromScrapedValue('PreOrder', $config));
+        $this->assertSame(StockStatus::Discontinued, StockStatus::matchFromScrapedValue('Discontinued', $config));
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('InStock', $config));
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('SomethingElse', $config));
+    }
+
+    public function test_match_from_scraped_value_with_legacy_string_config()
+    {
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('OutOfStock', 'OutOfStock'));
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('PreOrder', 'OutOfStock'));
+    }
+
+    public function test_match_from_scraped_value_with_null_config_fallback()
+    {
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('anything', null));
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('OutOfStock', null));
+    }
+
+    public function test_match_from_scraped_value_skips_empty_entries()
+    {
+        $config = [
+            'out_of_stock' => 'OutOfStock',
+            'pre_order' => '',
+            'discontinued' => null,
+        ];
+
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('OutOfStock', $config));
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('PreOrder', $config));
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('Discontinued', $config));
+    }
+
+    public function test_match_from_scraped_value_with_regex_match()
+    {
+        $config = [
+            'out_of_stock' => ['type' => 'regex', 'value' => 'Sold out'],
+        ];
+
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('Sold out', $config));
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('SOLD OUT', $config));
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('This item is Sold out now', $config));
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('In Stock', $config));
+    }
+
+    public function test_match_from_scraped_value_regex_first_match_wins()
+    {
+        $config = [
+            'special_order' => ['type' => 'regex', 'value' => 'Special Order'],
+            'out_of_stock' => ['type' => 'regex', 'value' => 'Sold out'],
+        ];
+
+        // Both patterns match, but special_order is iterated first so it wins.
+        $this->assertSame(
+            StockStatus::SpecialOrder,
+            StockStatus::matchFromScrapedValue('Sold out - We May Be Able To Special Order', $config)
+        );
+    }
+
+    public function test_match_from_scraped_value_mixed_regex_and_exact()
+    {
+        $config = [
+            'pre_order' => ['type' => 'match', 'value' => 'Pre-Order'],
+            'out_of_stock' => ['type' => 'regex', 'value' => 'sold out'],
+        ];
+
+        $this->assertSame(StockStatus::PreOrder, StockStatus::matchFromScrapedValue('Pre-Order', $config));
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('Sold Out', $config));
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('Available', $config));
+    }
+
+    public function test_match_from_scraped_value_invalid_regex_does_not_match()
+    {
+        $config = [
+            'out_of_stock' => ['type' => 'regex', 'value' => '[invalid'],
+        ];
+
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('anything', $config));
+    }
+
+    public function test_match_from_scraped_value_empty_config_uses_default()
+    {
+        // All entries empty → uses default (InStock when no default key).
+        $config = [
+            'out_of_stock' => ['type' => 'regex', 'value' => ''],
+            'pre_order' => ['type' => 'match', 'value' => ''],
+        ];
+
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('anything', $config));
+
+        // Same for legacy empty entries.
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('anything', [
+            'out_of_stock' => '',
+            'pre_order' => null,
+        ]));
+
+        // With explicit default.
+        $config['default'] = 'out_of_stock';
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('anything', $config));
+    }
+
+    public function test_match_from_scraped_value_defaults_to_match_type()
+    {
+        $config = [
+            'out_of_stock' => ['value' => 'OutOfStock'],
+        ];
+
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('OutOfStock', $config));
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('out of stock', $config));
+    }
+
+    public function test_match_from_scraped_value_uses_configurable_default()
+    {
+        // Default to OutOfStock when no match values match.
+        $config = [
+            'default' => 'out_of_stock',
+            'pre_order' => ['type' => 'match', 'value' => 'Pre-Order'],
+        ];
+
+        $this->assertSame(StockStatus::PreOrder, StockStatus::matchFromScrapedValue('Pre-Order', $config));
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::matchFromScrapedValue('something else', $config));
+
+        // Default to InStock (explicit).
+        $config['default'] = 'in_stock';
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('something else', $config));
+
+        // No default key → defaults to InStock.
+        unset($config['default']);
+        $this->assertSame(StockStatus::InStock, StockStatus::matchFromScrapedValue('something else', $config));
+    }
+
+    public function test_non_in_stock_cases_returns_five_cases()
+    {
+        $cases = StockStatus::nonInStockCases();
+
+        $this->assertCount(5, $cases);
+        $this->assertNotContains(StockStatus::InStock, $cases);
+        $this->assertContains(StockStatus::PreOrder, $cases);
+        $this->assertContains(StockStatus::BackOrder, $cases);
+        $this->assertContains(StockStatus::SpecialOrder, $cases);
+        $this->assertContains(StockStatus::OutOfStock, $cases);
+        $this->assertContains(StockStatus::Discontinued, $cases);
+    }
+}


### PR DESCRIPTION
Add availability field to URLs for tracking product stock status (in stock, pre-order, back order, special order, out of stock, discontinued). Includes configurable match rules per store with exact match and regex support, priority-based matching, and a default status fallback. Out-of-stock products can now be added with price set to 0. Added The Tech Geeks store with availability detection and seeded Ubiquiti products.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Product availability tracking with six statuses; availability included in price data and in-stock items sorted before unavailable ones.
  * Store configuration supports mapping scraped availability to statuses; seed data includes new store and updated rules.
  * URL/product creation and updates handle unavailable scrapes and may record zero price when no price is present.

* **UI/UX Improvements**
  * Availability badges, icons, labels and colors shown across product lists, cards and stats.

* **Tests / Chores**
  * Added tests covering availability parsing, ordering and pricing; database and factory/seeder updates included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->