### PR TITLE
GotifyChannel using the wrong format for gotify messages.

### DIFF
--- a/app/Notifications/Channels/GotifyChannel.php
+++ b/app/Notifications/Channels/GotifyChannel.php
@@ -63,8 +63,8 @@ class GotifyChannel
             'extras' => [
                 'client::notification' => [
                     'click' => [
-						'url' => $url,
-					],
+                        'url' => $url,
+                    ],
                 ],
             ],
         ]);

--- a/app/Notifications/Channels/GotifyChannel.php
+++ b/app/Notifications/Channels/GotifyChannel.php
@@ -62,7 +62,9 @@ class GotifyChannel
             'priority' => $priority,
             'extras' => [
                 'client::notification' => [
-                    'click' => $url,
+                    'click' => [
+						'url' =>$url,
+					],
                 ],
             ],
         ]);

--- a/app/Notifications/Channels/GotifyChannel.php
+++ b/app/Notifications/Channels/GotifyChannel.php
@@ -63,7 +63,7 @@ class GotifyChannel
             'extras' => [
                 'client::notification' => [
                     'click' => [
-						'url' =>$url,
+						'url' => $url,
 					],
                 ],
             ],


### PR DESCRIPTION
It looks like the gotify notification message format isn't valid, at least for the latest version of gotify. Tested this locally and it resolves the issue.
issue mentioned in #136 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Gotify notification payload formatting so click actions are sent in the expected structure rather than as a plain string. This improves compatibility with Gotify and restores reliable click behavior for notifications, ensuring links open correctly when notifications are tapped.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->