### PR TITLE
feat: Add cookies option to store

### DIFF
--- a/app/Filament/Resources/StoreResource.php
+++ b/app/Filament/Resources/StoreResource.php
@@ -92,6 +92,12 @@ class StoreResource extends Resource
                     ->columns(2)
                     ->schema(AppSettingsPage::getLocaleFormFields('settings.locale_settings')),
 
+                Forms\Components\Section::make('Cookies')->schema([
+                    TextInput::make('cookies')
+                        ->label('Cookies')
+                        ->hintIcon(Icons::Help->value, 'Any cookies to include in scrape requests for this store. Format as you would in an HTTP header, e.g. "cookie1=value; cookie2=value"'),
+                ])->description('Optional cookies to include in scrape requests for this store'),
+
                 Forms\Components\Section::make('Notes')->schema([
                     Forms\Components\RichEditor::make('notes')
                         ->hiddenLabel(true),

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -32,6 +32,7 @@ use Spatie\Sluggable\SlugOptions;
  * @property Collection $urls
  * @property Collection $products
  * @property ?User $user
+ * @property ?string $cookies
  */
 class Store extends Model
 {
@@ -48,6 +49,7 @@ class Store extends Model
         'settings',
         'notes',
         'user_id',
+        'cookies',
     ];
 
     protected function casts(): array

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -170,6 +170,10 @@ class ScrapeUrl
                 ->setUseCache($useCache)
                 ->setOptions($store->scraper_options);
 
+            if ($store->cookies) {
+                $scraper->setCookies($store->cookies);
+            }
+
             $page = $scraper->get();
 
             if ($errors = $scraper->getErrors()) {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "filament/filament": "^3.2",
         "filament/forms": "^3.2",
         "filament/spatie-laravel-settings-plugin": "^3.2",
-        "jez500/web-scraper-for-laravel": "^1.0.8",
+        "jez500/web-scraper-for-laravel": "^1.0.9",
         "laravel-notification-channels/pushover": "^4.0",
         "laravel/framework": "^12.0",
         "laravel/sanctum": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "58e80e30ead84c4a213fceed63f40d33",
+    "content-hash": "b1308c4b2ded8599342f32826588b5d2",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -2346,16 +2346,16 @@
         },
         {
             "name": "jez500/web-scraper-for-laravel",
-            "version": "1.0.8",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jez500/Web-scraper-for-Laravel.git",
-                "reference": "b2c943e718425bc5bda50787abef0970667e8df3"
+                "reference": "8ccef0e272cd0376cce25bc4115904f1fee13232"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jez500/Web-scraper-for-Laravel/zipball/b2c943e718425bc5bda50787abef0970667e8df3",
-                "reference": "b2c943e718425bc5bda50787abef0970667e8df3",
+                "url": "https://api.github.com/repos/jez500/Web-scraper-for-Laravel/zipball/8ccef0e272cd0376cce25bc4115904f1fee13232",
+                "reference": "8ccef0e272cd0376cce25bc4115904f1fee13232",
                 "shasum": ""
             },
             "require": {
@@ -2394,9 +2394,9 @@
             "description": "A web scraper for laravel",
             "support": {
                 "issues": "https://github.com/jez500/Web-scraper-for-Laravel/issues",
-                "source": "https://github.com/jez500/Web-scraper-for-Laravel/tree/1.0.8"
+                "source": "https://github.com/jez500/Web-scraper-for-Laravel/tree/1.0.9"
             },
-            "time": "2026-03-01T03:40:07+00:00"
+            "time": "2026-03-22T23:08:13+00:00"
         },
         {
             "name": "kirschbaum-development/eloquent-power-joins",
@@ -13387,5 +13387,5 @@
         "ext-intl": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/database/migrations/2026_03_13_230243_add_cookies_to_stores_table.php
+++ b/database/migrations/2026_03_13_230243_add_cookies_to_stores_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('stores', function (Blueprint $table) {
+            $table->text('cookies')->nullable()->after('notes');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('stores', function (Blueprint $table) {
+            $table->dropColumn('cookies');
+        });
+    }
+};


### PR DESCRIPTION
This pull request adds functionality to set cookies in store settings. This is useful for websites that render content differently depending on what cookies are set.

For example, Amazon US will render prices in user's local currency (based on client IP address). However, it can be changed to a different currency by setting the `i18n-prefs` cookie to, for example, `USD`.

The problem with local currencies is that, if currency is set to `USD` in store settings, extracted prices will be wrong because prices are shown in a different currency. This can of course be fixed by setting currency in store settings to whatever is being served from store, but that's not always ideal for everyone.

## Codebase updates

- Add `cookies` column to `stores` table in the `database/migrations/2026_03_13_230243_add_cookies_to_stores_table.php` migration.
- Add `cookies` field to the `app/Models/Store.php` model.
- Update the `jez500/web-scraper-for-laravel` package in the `composer.json` file to gain the cookies functionality from the scraping interface.
- Add `setCookies` call in the `app/Services/ScrapeUrl.php` file, if store has `cookies` field set.
- Add cookies field to the `app/Filament/Resources/StoreResource.php` filament form.

## Manual testing

The following tests has been performed with both, HTTP and API based scraping services:

- Go to Products -> Add product
- Add any product from Amazon US. The currency will be assumed to be `USD` as per store settings, however, depending on your location it may be something else. Therefore the extracted number will also be wrong.
- Go to Stores -> Amazon US
- Set cookies field to `i18n-prefs=USD`
- Go to Products -> Add product
- Add any product from Amazon US. The extracted number should be correct now.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cookie management for stores—specify cookies to be automatically included in web scraping requests for each store
  * Cookie configuration is optional and uses standard format: `cookie1=value; cookie2=value`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->