### PR TITLE
fix: Validate URL format before scraping to prevent fatal error

### DIFF
--- a/app/Rules/StoreUrl.php
+++ b/app/Rules/StoreUrl.php
@@ -15,11 +15,17 @@ class StoreUrl implements DataAwareRule, ValidationRule
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
+        if (empty($value) || ! filter_var($value, FILTER_VALIDATE_URL)) {
+            $fail('The url must be a valid URL starting with http:// or https://');
+
+            return;
+        }
+
         $store = ScrapeUrl::new($value)->getStore();
 
         $shouldCreateStore = data_get($this->data, 'data.create_store', true);
 
-        if (empty($value) || (empty($store) && ! $shouldCreateStore)) {
+        if (empty($store) && ! $shouldCreateStore) {
             $fail('The domain does not belong to any stores');
         }
 


### PR DESCRIPTION
## Summary

Adds URL format validation in the `StoreUrl` rule before the URL is passed to `ScrapeUrl`. URLs without a valid scheme (like entering `amazon.com` instead of `https://amazon.com`) now return a validation error instead of causing a fatal crash.

## Changes

**File:** `app/Rules/StoreUrl.php`

- Added `filter_var($value, FILTER_VALIDATE_URL)` check at the start of the `validate()` method with an early return
- Removed the now-redundant `empty($value)` check from the store existence condition (already handled by the new guard)

## Testing

- `FILTER_VALIDATE_URL` rejects URLs missing the scheme, malformed strings, and empty values
- Valid URLs like `https://amazon.com/product/123` pass through unchanged

Closes #105

This contribution was developed with AI assistance (Claude Code).