### PR TITLE
fix: out-of-stock scrape flow on Coles/Woolworths/BigW + related bugs

### DIFF
--- a/app/Dto/PriceCacheDto.php
+++ b/app/Dto/PriceCacheDto.php
@@ -201,6 +201,15 @@ class PriceCacheDto
 
     public function isLastScrapeSuccessful(): bool
     {
+        // Out-of-stock URLs don't get fresh Price rows by design (`Url::updatePrice`
+        // doesn't insert when the scrape returns no price), so the price-history
+        // timestamp will lag arbitrarily far behind reality. Treat them as fresh
+        // so the product doesn't show a "scrape error" badge while it's just
+        // genuinely unavailable.
+        if ($this->isUnavailable()) {
+            return true;
+        }
+
         $hours = $this->getHoursSinceLastScrape();
 
         return $hours && $hours < 24;

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -221,6 +221,7 @@ class Url extends Model
         }
 
         $availabilityChanged = false;
+        $stockStatus = null;
 
         if (is_null($price) || $price === '') {
             $scrapeResult = $scrapeResult ?? $this->scrape();
@@ -244,6 +245,15 @@ class Url extends Model
         if (is_null($price) || $price === '') {
             if ($availabilityChanged) {
                 $this->product?->updatePriceCache();
+            }
+
+            // An out-of-stock product with no scraped price is the expected
+            // outcome, not a failure. Keep the existing price history (we
+            // don't insert a new row) and return the latest known Price so
+            // the parent `Product::updatePrices()` doesn't count this URL
+            // as failed and trigger a scrape-error notification.
+            if ($stockStatus?->isUnavailable()) {
+                return $this->prices()->latest('id')->first();
             }
 
             return null;

--- a/app/Services/AutoCreateStore.php
+++ b/app/Services/AutoCreateStore.php
@@ -261,7 +261,7 @@ class AutoCreateStore
             }
 
             try {
-                preg_match_all($regex, $this->html, $matches);
+                preg_match_all(ScrapeUrl::ensureRegexDelimiters($regex), $this->html, $matches);
                 $extracted = data_get($matches, '1.0');
 
                 $value = is_null($validateValue)

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -233,6 +233,7 @@ class ScrapeUrl
 
         $value = match ($type) {
             ScraperStrategyType::Selector->value => self::parseSelector($value),
+            ScraperStrategyType::Regex->value => [self::ensureRegexDelimiters($value)],
             default => [$value]
         };
 
@@ -266,6 +267,35 @@ class ScrapeUrl
             ScraperStrategyType::SchemaOrg->value => 'getSchemaOrg',
             default => 'getSelector'
         };
+    }
+
+    /**
+     * Wrap a user-supplied regex pattern in delimiters if it doesn't already have them.
+     *
+     * PHP's preg_* functions require pattern delimiters; bare patterns saved in the
+     * store strategy config (e.g. `https?://schema.org/(\w+)`) raise a warning and
+     * silently return no matches. Picks a delimiter that does not appear in the pattern.
+     */
+    public static function ensureRegexDelimiters(string $regex): string
+    {
+        if ($regex === '') {
+            return $regex;
+        }
+
+        $first = $regex[0];
+
+        // First char is a valid PHP regex delimiter — assume already delimited.
+        if (! ctype_alnum($first) && $first !== '\\' && ! ctype_space($first)) {
+            return $regex;
+        }
+
+        foreach (['#', '~', '%', '@', '!'] as $delimiter) {
+            if (! str_contains($regex, $delimiter)) {
+                return $delimiter.$regex.$delimiter;
+            }
+        }
+
+        return '#'.str_replace('#', '\\#', $regex).'#';
     }
 
     public static function parseSelector(string $selector): array

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -229,6 +229,15 @@ class ScrapeUrl
         $type = data_get($options, 'type');
         $value = data_get($options, 'value');
 
+        // A strategy entry can exist with `type` left null (e.g. an incomplete
+        // store config where the availability slot has the match table set but
+        // no extraction type). Without this guard, `getMethodFromType(null)`
+        // throws a TypeError and the whole scrape — including unrelated fields —
+        // fails with a 500.
+        if (! is_string($type) || $type === '') {
+            return null;
+        }
+
         $method = self::getMethodFromType($type);
 
         $value = match ($type) {

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -238,6 +238,13 @@ class ScrapeUrl
             return null;
         }
 
+        // A strategy slot can have its type set but value left null; the scraper
+        // methods (getRegex, getSelector, ...) are typed `string`, so skip rather
+        // than passing null and triggering a TypeError. SchemaOrg ignores value.
+        if (! is_string($value) && $type !== ScraperStrategyType::SchemaOrg->value) {
+            return null;
+        }
+
         $method = self::getMethodFromType($type);
 
         $value = match ($type) {
@@ -291,10 +298,7 @@ class ScrapeUrl
             return $regex;
         }
 
-        $first = $regex[0];
-
-        // First char is a valid PHP regex delimiter — assume already delimited.
-        if (! ctype_alnum($first) && $first !== '\\' && ! ctype_space($first)) {
+        if (self::hasMatchingDelimiters($regex)) {
             return $regex;
         }
 
@@ -305,6 +309,44 @@ class ScrapeUrl
         }
 
         return '#'.str_replace('#', '\\#', $regex).'#';
+    }
+
+    /**
+     * Determine whether a pattern is already wrapped in valid PHP regex delimiters.
+     *
+     * Accepts a known single-char delimiter (/ # ~ % @ ! |) repeated at the end, or
+     * an opening paired delimiter ( { [ < closed by its partner ) } ] > — in either
+     * case optionally followed by valid modifier letters. A bare pattern that merely
+     * starts with a non-alphanumeric char (e.g. `$([0-9.]+)`) is NOT treated as
+     * delimited, so it gets wrapped instead of failing preg_* silently.
+     */
+    private static function hasMatchingDelimiters(string $regex): bool
+    {
+        if (strlen($regex) < 2) {
+            return false;
+        }
+
+        $paired = ['(' => ')', '{' => '}', '[' => ']', '<' => '>'];
+        $single = ['/', '#', '~', '%', '@', '!', '|'];
+
+        $first = $regex[0];
+
+        if (isset($paired[$first])) {
+            $closing = $paired[$first];
+        } elseif (in_array($first, $single, true)) {
+            $closing = $first;
+        } else {
+            return false;
+        }
+
+        // Walk back over trailing modifier letters to find the closing delimiter.
+        $index = strlen($regex) - 1;
+        while ($index > 0 && str_contains('imsxADSUXJun', $regex[$index])) {
+            $index--;
+        }
+
+        // The closing delimiter must sit past the opening one (non-empty body).
+        return $index >= 1 && $regex[$index] === $closing;
     }
 
     public static function parseSelector(string $selector): array

--- a/tests/Feature/Models/UrlTest.php
+++ b/tests/Feature/Models/UrlTest.php
@@ -227,6 +227,89 @@ class UrlTest extends TestCase
         $this->assertSame(StockStatus::OutOfStock, $url->fresh()->availability);
     }
 
+    public function test_update_price_unavailable_with_existing_price_returns_latest_and_keeps_history()
+    {
+        // Regression: when a URL with an existing price history goes out of
+        // stock, `updatePrice` previously returned null. `Product::updatePrices`
+        // counts null returns as failures, which would surface as a "scrape
+        // error" on the product page for a product that is just out of stock.
+        // The latest known price should be returned so the parent doesn't
+        // consider this URL failed, and no new price row should be inserted.
+        $product = Product::factory()->create();
+        $url = Url::factory()->createOne([
+            'url' => self::TEST_URL,
+            'product_id' => $product->id,
+            'store_id' => $this->store->id,
+        ]);
+        /** @var Price $existing */
+        $existing = $url->prices()->create([
+            'price' => 12.5,
+            'unit_price' => 12.5,
+            'price_factor' => 1,
+            'store_id' => $this->store->id,
+        ]);
+
+        $this->store->update([
+            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+                'availability' => [
+                    'type' => 'selector',
+                    'value' => '.availability',
+                    'match' => [
+                        'out_of_stock' => ['type' => 'match', 'value' => 'OutOfStock'],
+                        'default' => 'in_stock',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $this->mockScrape('', 'foo', null, 'OutOfStock');
+
+        $priceModel = $url->updatePrice();
+
+        $this->assertInstanceOf(Price::class, $priceModel);
+        $this->assertSame($existing->id, $priceModel->id);
+        $this->assertCount(1, $url->fresh()->prices);
+        $this->assertSame(StockStatus::OutOfStock, $url->fresh()->availability);
+    }
+
+    public function test_product_update_prices_is_successful_when_only_url_goes_out_of_stock()
+    {
+        // Regression for the same path at the product level: a product with a
+        // single URL that goes out of stock should not be reported as a
+        // failed scrape (which fires ScrapeFailNotification + UI error).
+        $product = Product::factory()->create();
+        $url = Url::factory()->createOne([
+            'url' => self::TEST_URL,
+            'product_id' => $product->id,
+            'store_id' => $this->store->id,
+        ]);
+        $url->prices()->create([
+            'price' => 9.99,
+            'unit_price' => 9.99,
+            'price_factor' => 1,
+            'store_id' => $this->store->id,
+        ]);
+
+        $this->store->update([
+            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+                'availability' => [
+                    'type' => 'selector',
+                    'value' => '.availability',
+                    'match' => [
+                        'out_of_stock' => ['type' => 'match', 'value' => 'OutOfStock'],
+                        'default' => 'in_stock',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $this->mockScrape('', 'foo', null, 'OutOfStock');
+
+        $successful = $product->fresh()->updatePrices();
+
+        $this->assertTrue($successful);
+    }
+
     public function test_update_price_unavailable_to_in_stock_creates_price_and_clears_availability()
     {
         $product = Product::factory()->create();

--- a/tests/Unit/Dto/PriceCacheDtoTest.php
+++ b/tests/Unit/Dto/PriceCacheDtoTest.php
@@ -200,4 +200,51 @@ class PriceCacheDtoTest extends TestCase
         $this->assertTrue($dto->isUnavailable());
         $this->assertSame(StockStatus::OutOfStock, $dto->getStockStatus());
     }
+
+    public function test_unavailable_url_is_considered_successfully_scraped_despite_stale_price_row()
+    {
+        // Regression: OOS URLs don't get new price rows inserted by
+        // Url::updatePrice, so last_scrape lags arbitrarily far behind.
+        // The "Scrape error" badge in the product UI is gated on
+        // isLastScrapeSuccessful(); without this guard an OOS product is
+        // permanently flagged as a scrape failure.
+        $dto = PriceCacheDto::fromArray([
+            'price' => 10.0,
+            'history' => [],
+            'availability' => StockStatus::OutOfStock->value,
+            'last_scrape' => now()->subMonths(3)->toDateTimeString(),
+            'locale' => 'en',
+            'currency' => 'USD',
+        ]);
+
+        $this->assertTrue($dto->isUnavailable());
+        $this->assertTrue($dto->isLastScrapeSuccessful());
+    }
+
+    public function test_in_stock_url_with_stale_price_row_is_unsuccessful()
+    {
+        $dto = PriceCacheDto::fromArray([
+            'price' => 10.0,
+            'history' => [],
+            'last_scrape' => now()->subDays(2)->toDateTimeString(),
+            'locale' => 'en',
+            'currency' => 'USD',
+        ]);
+
+        $this->assertFalse($dto->isUnavailable());
+        $this->assertFalse($dto->isLastScrapeSuccessful());
+    }
+
+    public function test_in_stock_url_with_recent_price_row_is_successful()
+    {
+        $dto = PriceCacheDto::fromArray([
+            'price' => 10.0,
+            'history' => [],
+            'last_scrape' => now()->subHours(2)->toDateTimeString(),
+            'locale' => 'en',
+            'currency' => 'USD',
+        ]);
+
+        $this->assertTrue($dto->isLastScrapeSuccessful());
+    }
 }

--- a/tests/Unit/Services/ScrapeUrlTest.php
+++ b/tests/Unit/Services/ScrapeUrlTest.php
@@ -129,6 +129,11 @@ class ScrapeUrlTest extends TestCase
             'tilde-delimited passes through' => ['~foo~', '~foo~'],
             'pattern containing # picks the next available delimiter' => ['fragment#section', '~fragment#section~'],
             'empty string is returned unchanged' => ['', ''],
+            'dollar-anchored bare pattern is wrapped, not treated as delimited' => ['$([0-9.]+)', '#$([0-9.]+)#'],
+            'single delimiter with no closing delimiter is wrapped' => ['/foo', '#/foo#'],
+            'paired parens delimiter passes through' => ['(\d+)', '(\d+)'],
+            'paired braces delimiter passes through' => ['{\d+}', '{\d+}'],
+            'bare char class with quantifier is wrapped' => ['[0-9]+', '#[0-9]+#'],
         ];
     }
 
@@ -186,6 +191,30 @@ class ScrapeUrlTest extends TestCase
         $result = ScrapeUrl::new(self::TEST_URL)->scrape();
 
         // Other fields scrape normally; availability is skipped (null).
+        $this->assertSame('Example Title', $result['title']);
+        $this->assertSame('$10.00', $result['price']);
+        $this->assertNull($result['availability']);
+    }
+
+    public function test_scrape_regex_strategy_with_null_value_does_not_throw()
+    {
+        // A regex strategy slot can have its `type` set but `value` left null.
+        // ensureRegexDelimiters() is typed `string`, so passing the null value
+        // straight through the Regex match arm raised an uncaught TypeError and
+        // failed the whole scrape. The arm now guards on is_string().
+        $this->store->update([
+            'scrape_strategy' => [
+                'title' => ['type' => 'selector', 'value' => 'meta[property=og:title]|content'],
+                'price' => ['type' => 'selector', 'value' => 'meta[property=og:price:amount]|content'],
+                'image' => ['type' => 'selector', 'value' => 'meta[property=og:image]|content'],
+                'availability' => ['type' => 'regex', 'value' => null],
+            ],
+        ]);
+
+        $this->mockScrape('$10.00', 'Example Title', 'https://example.com/x.png');
+
+        $result = ScrapeUrl::new(self::TEST_URL)->scrape();
+
         $this->assertSame('Example Title', $result['title']);
         $this->assertSame('$10.00', $result['price']);
         $this->assertNull($result['availability']);

--- a/tests/Unit/Services/ScrapeUrlTest.php
+++ b/tests/Unit/Services/ScrapeUrlTest.php
@@ -118,6 +118,50 @@ class ScrapeUrlTest extends TestCase
         $this->assertEquals('$10.00', $result['price']);
     }
 
+    public static function regexDelimiterCases(): array
+    {
+        return [
+            'bare alphanumeric start is wrapped' => ['https?://schema.org/(\w+)', '#https?://schema.org/(\w+)#'],
+            'bare backslash start is wrapped' => ['\d+', '#\d+#'],
+            'slash-delimited passes through' => ['/foo/', '/foo/'],
+            'slash-delimited with flags passes through' => ['/foo/i', '/foo/i'],
+            'hash-delimited passes through' => ['#https?://schema.org/(\w+)#', '#https?://schema.org/(\w+)#'],
+            'tilde-delimited passes through' => ['~foo~', '~foo~'],
+            'pattern containing # picks the next available delimiter' => ['fragment#section', '~fragment#section~'],
+            'empty string is returned unchanged' => ['', ''],
+        ];
+    }
+
+    /**
+     * @dataProvider regexDelimiterCases
+     */
+    public function test_ensure_regex_delimiters(string $input, string $expected)
+    {
+        $this->assertSame($expected, ScrapeUrl::ensureRegexDelimiters($input));
+    }
+
+    public function test_scrape_regex_strategy_accepts_bare_pattern()
+    {
+        // Store strategies historically saved availability as a bare regex
+        // (no delimiters), e.g. `https?://schema.org/(\w+)`. Without the fix,
+        // preg_match_all warns "Delimiter must not be alphanumeric" and the
+        // availability is silently null. This regression-tests that.
+        $this->store->update([
+            'scrape_strategy' => [
+                'title' => ['type' => 'selector', 'value' => 'meta[property=og:title]|content'],
+                'price' => ['type' => 'selector', 'value' => 'meta[property=og:price:amount]|content'],
+                'image' => ['type' => 'selector', 'value' => 'meta[property=og:image]|content'],
+                'availability' => ['type' => 'regex', 'value' => 'https?://schema.org/(\w+)'],
+            ],
+        ]);
+
+        $this->mockScrape('$10.00', 'Example Title', 'https://example.com/x.png', 'http://schema.org/OutOfStock');
+
+        $result = ScrapeUrl::new(self::TEST_URL)->scrape();
+
+        $this->assertSame('OutOfStock', $result['availability']);
+    }
+
     public function test_scrape_schema_org()
     {
         $this->store->update([

--- a/tests/Unit/Services/ScrapeUrlTest.php
+++ b/tests/Unit/Services/ScrapeUrlTest.php
@@ -162,6 +162,35 @@ class ScrapeUrlTest extends TestCase
         $this->assertSame('OutOfStock', $result['availability']);
     }
 
+    public function test_scrape_skips_strategy_entry_with_null_type()
+    {
+        // Real-world: a seeded store can have a strategy slot (e.g. availability)
+        // with the match table populated but `type` left null. Before the guard,
+        // this raised a TypeError in getMethodFromType and the whole scrape — for
+        // every field, not just availability — bailed with a 500.
+        $this->store->update([
+            'scrape_strategy' => [
+                'title' => ['type' => 'selector', 'value' => 'meta[property=og:title]|content'],
+                'price' => ['type' => 'selector', 'value' => 'meta[property=og:price:amount]|content'],
+                'image' => ['type' => 'selector', 'value' => 'meta[property=og:image]|content'],
+                'availability' => [
+                    'type' => null,
+                    'value' => null,
+                    'match' => ['default' => 'in_stock'],
+                ],
+            ],
+        ]);
+
+        $this->mockScrape('$10.00', 'Example Title', 'https://example.com/x.png');
+
+        $result = ScrapeUrl::new(self::TEST_URL)->scrape();
+
+        // Other fields scrape normally; availability is skipped (null).
+        $this->assertSame('Example Title', $result['title']);
+        $this->assertSame('$10.00', $result['price']);
+        $this->assertNull($result['availability']);
+    }
+
     public function test_scrape_schema_org()
     {
         $this->store->update([


### PR DESCRIPTION
## Summary

Four related bugs surfaced while trying to get out-of-stock detection working on the seeded Coles/Woolworths/BigW stores. Each is addressed in its own commit; everything stays in-place with no schema changes.

### 1. Regex strategies stored without delimiters silently fail (`f097f85`)

The seeded `availability` strategy for **Coles AU**, **Woolworths AU**, **Swaggle.com.au**, **Aqarastore.com.au** uses `type: regex` with value `https?://schema.org/(\w+)`. PHP's `preg_match_all` rejects patterns that don't start with a valid delimiter and emits:

> `preg_match_all(): Delimiter must not be alphanumeric, backslash, or NUL byte`

The warning is non-fatal, so the call silently returns no matches and availability stays `null`. End result: out-of-stock products at those retailers were always treated as in-stock and the "Missing required field: price" notification fired instead.

Adds `ScrapeUrl::ensureRegexDelimiters()`:
- pass-through if the first char is already a valid delimiter,
- otherwise pick the first of `#`, `~`, `%`, `@`, `!` that doesn't appear in the pattern,
- fall back to escaping `#`.

Wraps the value at both call sites that hand user-supplied regex straight to PCRE — `ScrapeUrl::scrapeOption()` (runtime extraction) and `AutoCreateStore::attemptRegex()` (strategy discovery).

### 2. Null `type` in a strategy entry → fatal TypeError (`bda9139`)

When a store has a strategy slot whose `type` is null but the surrounding entry is non-empty (e.g. Big W's seeded `availability` block with the match table populated but no extraction type), `ScrapeUrl::scrapeOption` passes the null to `getMethodFromType(string)` and the whole scrape — including unrelated title/price/image fields — bombs with 500. Adds an early `! is_string($type) || $type === ''` guard.

### 3. OOS URL with empty price was counted as failed (`b649015`)

`Url::updatePrice()` returned `null` whenever the scrape produced no price. `Product::updatePrices()` filters nulls and reports any null as a failure → `ScrapeFailNotification` → user gets emailed about a "scrape error" every time a product genuinely goes out of stock. Existing price history is left untouched (we still don't insert a new Price row), but the latest existing `Price` is now returned so the parent doesn't count the URL as failed.

### 4. OOS products permanently show "Scrape error" badge (`7263b9d`)

`PriceCacheDto::isLastScrapeSuccessful()` checks for a Price row in the last 24h. Because (3) correctly doesn't insert new rows for OOS URLs, the timestamp lags arbitrarily and the badge stays on forever. Treats unavailable URLs as fresh — the actual stock status is already rendered separately via the existing OOS badge.

## Test plan

- 4 new unit tests on `ScrapeUrl::ensureRegexDelimiters` (data provider covering bare/delimited/empty/`#`-in-pattern fallback)
- 1 new end-to-end test on `ScrapeUrl::scrape()` confirming a bare-regex availability strategy now extracts the captured group
- 1 new test that a strategy entry with `type: null` is skipped instead of throwing
- 2 new tests on `Url::updatePrice()` covering the OOS-with-history return value and the parent's success count
- 3 new tests on `PriceCacheDto::isLastScrapeSuccessful()` distinguishing OOS-stale / in-stock-stale / in-stock-recent

Locally on lando: 71 / 72 pass (the one pre-existing failure is `test_scrape_schema_org` calling `getSchemaOrg()` on `WebScraperHttp`, which exists on `main` too and is unrelated). `pint` is clean.

End-to-end verified against the live deployment: the four affected stores' availability now resolves correctly, the Big W URL that 500'd renders cleanly, OOS products keep their price history, and the admin product page no longer shows a phantom "Scrape error" badge for OOS products.

## Disclosure

I authored the code with Claude (Anthropic's AI) assisting on diagnosis, drafting, and writing the tests. I read every line, ran the test suite locally, and verified behaviour against my own running deployment before opening this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Out-of-stock items are no longer treated as failed scrapes; UI reflects availability correctly.
  * Existing price history is preserved when a URL or product goes out of stock.

* **Improvements**
  * Regex-based scraping patterns are normalized automatically to avoid extraction errors.
  * Scraping now safely skips invalid or missing strategy entries and null pattern values.

* **Tests**
  * Added unit and regression tests covering out-of-stock behavior and scraping edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->