### PR TITLE
Stop search after configurable priced result limit

### DIFF
--- a/app/Filament/Pages/AppSettingsPage.php
+++ b/app/Filament/Pages/AppSettingsPage.php
@@ -242,6 +242,13 @@ class AppSettingsPage extends SettingsPage
                     ->placeholder('Buy')
                     ->hintIcon(Icons::Help->value, __('Text to prepend to the product name when searching'))
                     ->nullable(),
+                TextInput::make('max_priced_results')
+                    ->label('Stop after this many priced results')
+                    ->hintIcon(Icons::Help->value, __('Search will stop once this many results with detected prices have been found'))
+                    ->numeric()
+                    ->minValue(1)
+                    ->required()
+                    ->default(SearchService::DEFAULT_MAX_PRICED_RESULTS),
                 Select::make('prune_days')
                     ->label('Cache duration')
                     ->required()

--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -9,6 +9,7 @@ use App\Models\Store;
 use App\Models\UrlResearch;
 use App\Services\Helpers\IntegrationHelper;
 use Exception;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -25,6 +26,8 @@ class SearchService
     public const int LOG_TTL_MINS = 60; // 1 hour
 
     public const int DEFAULT_MAX_PAGES = 1;
+
+    public const int DEFAULT_MAX_PRICED_RESULTS = 10;
 
     public Collection $results;
 
@@ -119,6 +122,14 @@ class SearchService
     public function getMaxPages(): int
     {
         return data_get(self::getSettings(), 'max_pages', self::DEFAULT_MAX_PAGES);
+    }
+
+    public function getMaxPricedResults(): int
+    {
+        return max(
+            1,
+            (int) data_get(self::getSettings(), 'max_priced_results', self::DEFAULT_MAX_PRICED_RESULTS)
+        );
     }
 
     public function getProductSourceResults(): self
@@ -261,30 +272,26 @@ class SearchService
         $this->log('Hydrating results');
 
         $existing = $this->getUrlResearch();
+        $maxPricedResults = $this->getMaxPricedResults();
+        $pricedResultsCount = 0;
+        $hydratedResults = collect();
 
-        $this->results = $this->results
-            ->map(function ($result) use ($existing) {
-                $logArgs = collect($result)->only(['title', 'url', 'domain'])->all();
+        foreach ($this->results as $result) {
+            $logArgs = collect($result)->only(['title', 'url', 'domain'])->all();
+            $cachedResult = $existing->get($result['url']);
 
-                if ($existing->get($result['url'])) {
-                    $this->log(__('Using cache ":title" (:domain)', $logArgs), ['subtitle' => $result['url'], 'icon' => Icons::Database->value]);
+            if ($cachedResult) {
+                $this->log(__('Using cache ":title" (:domain)', $logArgs), ['subtitle' => $result['url'], 'icon' => Icons::Database->value]);
 
-                    return $result;
-                }
-
+                $result = array_merge($result, Arr::only($cachedResult->toArray(), [
+                    'html', 'image', 'price', 'store_id', 'strategies', 'execution_time',
+                ]));
+            } else {
                 $timeStart = microtime(true);
                 $this->log(__('Analyzing ":title" (:domain)', $logArgs), ['subtitle' => $result['url']]);
 
                 try {
-                    $dto = new ProductResearchUrlDto(url: $result['url'], cached: true);
-
-                    $result = array_merge($result, [
-                        'price' => $dto->getPrice(),
-                        'image' => $dto->getImage(),
-                        'strategies' => $dto->getStrategies(),
-                        'is_product_page' => $dto->getIsProductPage()->value,
-                        'html' => $dto->getHtml(),
-                    ]);
+                    $result = array_merge($result, $this->getHydratedResultData($result));
 
                     if (! empty($result['price'])) {
                         $this->replaceLastLogEntry(__('Price found ":title" (:domain)', $logArgs));
@@ -297,11 +304,52 @@ class SearchService
                 }
 
                 $result['execution_time'] = (microtime(true) - $timeStart);
+            }
 
-                return $result;
-            });
+            $hydratedResults->push($result);
+            $this->persistUrlResearchResult($result);
+
+            if (empty($result['price'])) {
+                continue;
+            }
+
+            $pricedResultsCount++;
+
+            if ($pricedResultsCount < $maxPricedResults) {
+                continue;
+            }
+
+            $this->log(__('Stopping search after finding :count priced results', ['count' => $pricedResultsCount]));
+
+            break;
+        }
+
+        $this->results = $hydratedResults;
 
         return $this;
+    }
+
+    protected function getHydratedResultData(array $result): array
+    {
+        $dto = new ProductResearchUrlDto(url: $result['url'], cached: true);
+
+        return [
+            'price' => $dto->getPrice(),
+            'image' => $dto->getImage(),
+            'strategies' => $dto->getStrategies(),
+            'is_product_page' => $dto->getIsProductPage()->value,
+            'html' => $dto->getHtml(),
+        ];
+    }
+
+    protected function persistUrlResearchResult(array $result): void
+    {
+        UrlResearch::updateOrCreate(
+            ['url' => $result['url']],
+            collect($result)->only([
+                'html', 'title', 'image', 'price', 'store_id', 'strategies', 'execution_time',
+            ])->all()
+        );
     }
 
     public static function getSettings(): array

--- a/tests/Feature/Services/SearchServiceTest.php
+++ b/tests/Feature/Services/SearchServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Models\UrlResearch;
+use App\Services\Helpers\IntegrationHelper;
+use App\Services\SearchService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+uses(RefreshDatabase::class, TestCase::class);
+
+it('stops hydrating after the configured number of priced results', function () {
+    IntegrationHelper::setSettings([
+        'searxng' => [
+            'max_priced_results' => 2,
+        ],
+    ]);
+
+    $service = new class('laptop') extends SearchService
+    {
+        protected function getHydratedResultData(array $result): array
+        {
+            $price = match ($result['url']) {
+                'https://example.com/priced-1' => 100.0,
+                'https://example.com/priced-2' => 200.0,
+                'https://example.com/priced-3' => 300.0,
+                default => null,
+            };
+
+            return [
+                'price' => $price,
+                'image' => null,
+                'strategies' => [],
+                'is_product_page' => null,
+                'html' => null,
+            ];
+        }
+    };
+
+    $service->results = collect([
+        ['title' => 'One', 'url' => 'https://example.com/priced-1', 'domain' => 'example.com'],
+        ['title' => 'Two', 'url' => 'https://example.com/no-price', 'domain' => 'example.com'],
+        ['title' => 'Three', 'url' => 'https://example.com/priced-2', 'domain' => 'example.com'],
+        ['title' => 'Four', 'url' => 'https://example.com/priced-3', 'domain' => 'example.com'],
+    ]);
+
+    $service->hydrateWithScrapedData();
+
+    expect($service->results->pluck('url')->all())->toBe([
+        'https://example.com/priced-1',
+        'https://example.com/no-price',
+        'https://example.com/priced-2',
+    ]);
+
+    expect(UrlResearch::query()->pluck('url')->all())->toBe([
+        'https://example.com/priced-1',
+        'https://example.com/no-price',
+        'https://example.com/priced-2',
+    ]);
+
+    expect(UrlResearch::query()->whereNotNull('price')->count())->toBe(2);
+});

--- a/tests/Feature/Services/SearchServiceTest.php
+++ b/tests/Feature/Services/SearchServiceTest.php
@@ -51,7 +51,7 @@ it('stops hydrating after the configured number of priced results', function () 
         'https://example.com/priced-2',
     ]);
 
-    expect(UrlResearch::query()->pluck('url')->all())->toBe([
+    expect(UrlResearch::query()->orderBy('id')->pluck('url')->all())->toBe([
         'https://example.com/priced-1',
         'https://example.com/no-price',
         'https://example.com/priced-2',


### PR DESCRIPTION
## Summary
- add a configurable SearXNG setting to stop search hydration after a target number of priced results
- persist partial search results as they are hydrated so the product-selection step can proceed once the limit is reached
- add a regression test covering early stop behavior for priced results

## Why
Searches could continue scraping and analyzing results long after enough usable prices had already been found. That made the import flow feel unbounded even when the user already had enough products to choose from.

## Validation
- recreated the PriceBuddy app container with the patched PHP files mounted
- confirmed Laravel booted successfully via `php artisan about`
- confirmed the app still responded with HTTP 200 on `http://localhost:8080`
- added a regression test file for the early-stop path

## Notes
The shipped app image does not include PHPUnit/Pest dev binaries, so the new test file could not be executed inside that runtime image.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable limit for priced search results in App Settings. Default is 10, minimum 1.

* **Tests**
  * Added a feature test that verifies the priced-result limit is enforced during result hydration and persisted accordingly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jez500/pricebuddy/pull/168?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->