### PR TITLE
Fix/regex strategy delimiters

### DIFF
--- a/app/Dto/PriceCacheDto.php
+++ b/app/Dto/PriceCacheDto.php
@@ -201,6 +201,15 @@ class PriceCacheDto
 
     public function isLastScrapeSuccessful(): bool
     {
+        // Out-of-stock URLs don't get fresh Price rows by design (`Url::updatePrice`
+        // doesn't insert when the scrape returns no price), so the price-history
+        // timestamp will lag arbitrarily far behind reality. Treat them as fresh
+        // so the product doesn't show a "scrape error" badge while it's just
+        // genuinely unavailable.
+        if ($this->isUnavailable()) {
+            return true;
+        }
+
         $hours = $this->getHoursSinceLastScrape();
 
         return $hours && $hours < 24;

--- a/app/Filament/Resources/ProductResource.php
+++ b/app/Filament/Resources/ProductResource.php
@@ -63,7 +63,7 @@ class ProductResource extends Resource
         $components = [];
 
         if (is_null($productId)) {
-            $components[] = Forms\Components\Select::make('product_id')
+            $components[] = Select::make('product_id')
                 ->label('Existing product')
                 ->searchable(['title'])
                 ->getSearchResultsUsing(fn (string $search): array => auth()->user()->products()->where('title', 'like', "%{$search}%")
@@ -115,7 +115,7 @@ class ProductResource extends Resource
                     ->maxLength(50)
                     ->hintIcon(Icons::Help->value, 'Displayed after the price factor, e.g. (2 tablets)'),
 
-                Forms\Components\Select::make('status')
+                Select::make('status')
                     ->options(Statuses::class)
                     ->default(Statuses::Published)
                     ->preload()
@@ -163,7 +163,7 @@ class ProductResource extends Resource
                     ->placeholder('Search tags or create new...')
                     ->noSearchResultsMessage('No tags found'),
 
-                Forms\Components\Select::make('weight')
+                Select::make('weight')
                     ->label('Homepage sort order')
                     ->hintIcon(Icons::Help->value, 'The lower the number the higher it will appear on the homepage')
                     ->default('0')

--- a/app/Filament/Resources/ProductResource/Api/Handlers/CreateHandler.php
+++ b/app/Filament/Resources/ProductResource/Api/Handlers/CreateHandler.php
@@ -7,6 +7,7 @@ use App\Filament\Resources\ProductResource\Api\Requests\CreateProductRequest;
 use App\Filament\Resources\ProductResource\Api\Transformers\ProductTransformer;
 use App\Models\Url;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Rupadana\ApiService\Http\Handlers;
 
 #[Group(ProductResource::API_GROUP)]
@@ -29,7 +30,7 @@ class CreateHandler extends Handlers
     /**
      * Create Product
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(CreateProductRequest $request)
     {

--- a/app/Filament/Resources/ProductResource/Api/Handlers/DeleteHandler.php
+++ b/app/Filament/Resources/ProductResource/Api/Handlers/DeleteHandler.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\ProductResource\Api\Handlers;
 
 use App\Filament\Resources\ProductResource;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Rupadana\ApiService\Http\Handlers;
@@ -28,7 +29,7 @@ class DeleteHandler extends Handlers
     /**
      * Delete Product
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(Request $request)
     {

--- a/app/Filament/Resources/ProductResource/Api/Handlers/UpdateHandler.php
+++ b/app/Filament/Resources/ProductResource/Api/Handlers/UpdateHandler.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\ProductResource\Api\Handlers;
 use App\Filament\Resources\ProductResource;
 use App\Filament\Resources\ProductResource\Api\Requests\UpdateProductRequest;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Rupadana\ApiService\Http\Handlers;
 
 #[Group(ProductResource::API_GROUP)]
@@ -27,7 +28,7 @@ class UpdateHandler extends Handlers
     /**
      * Update Product
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(UpdateProductRequest $request)
     {

--- a/app/Filament/Resources/ProductResource/Api/Requests/CreateProductRequest.php
+++ b/app/Filament/Resources/ProductResource/Api/Requests/CreateProductRequest.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\ProductResource\Api\Requests;
 
 use App\Enums\Statuses;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class CreateProductRequest extends FormRequest
@@ -18,7 +19,7 @@ class CreateProductRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Filament/Resources/ProductResource/Api/Requests/UpdateProductRequest.php
+++ b/app/Filament/Resources/ProductResource/Api/Requests/UpdateProductRequest.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\ProductResource\Api\Requests;
 
 use App\Enums\Statuses;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateProductRequest extends FormRequest
@@ -18,7 +19,7 @@ class UpdateProductRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Filament/Resources/ProductResource/Api/Transformers/ProductTransformer.php
+++ b/app/Filament/Resources/ProductResource/Api/Transformers/ProductTransformer.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\ProductResource\Api\Transformers;
 use App\Filament\Resources\TagResource\Api\Transformers\TagTransformer;
 use App\Http\Resources\UserResource;
 use App\Models\Product;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
@@ -15,7 +16,7 @@ class ProductTransformer extends JsonResource
     /**
      * Transform the resource into an array.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return array
      */
     public function toArray($request)

--- a/app/Filament/Resources/ProductResource/Widgets/ProductUrlStats.php
+++ b/app/Filament/Resources/ProductResource/Widgets/ProductUrlStats.php
@@ -16,6 +16,7 @@ use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\HtmlString;
 
 class ProductUrlStats extends BaseWidget implements HasActions, HasForms
 {
@@ -120,7 +121,7 @@ class ProductUrlStats extends BaseWidget implements HasActions, HasForms
             ->form([
                 Placeholder::make('url')
                     ->label('URL')
-                    ->content(fn ($get) => new \Illuminate\Support\HtmlString(
+                    ->content(fn ($get) => new HtmlString(
                         '<span style="cursor:pointer" x-on:click="const range = document.createRange(); range.selectNodeContents($el); const sel = window.getSelection(); sel.removeAllRanges(); sel.addRange(range)">'.e($get('url')).'</span>'
                     )),
                 TextInput::make('price_factor')

--- a/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
+++ b/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\ProductResource\Widgets;
 
 use App\Models\Product;
 use App\Models\Url;
+use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -48,10 +49,10 @@ class UrlsTableWidget extends BaseWidget
             ->actions([
                 Tables\Actions\EditAction::make()
                     ->form([
-                        \Filament\Forms\Components\TextInput::make('url')
+                        TextInput::make('url')
                             ->label('URL')
                             ->disabled(),
-                        \Filament\Forms\Components\TextInput::make('price_factor')
+                        TextInput::make('price_factor')
                             ->label('Price Factor')
                             ->numeric()
                             ->default(1)

--- a/app/Filament/Resources/ProductSourceResource/Api/Handlers/CreateHandler.php
+++ b/app/Filament/Resources/ProductSourceResource/Api/Handlers/CreateHandler.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\ProductSourceResource;
 use App\Filament\Resources\ProductSourceResource\Api\Requests\CreateProductSourceRequest;
 use App\Filament\Resources\ProductSourceResource\Api\Transformers\ProductSourceTransformer;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Rupadana\ApiService\Http\Handlers;
 
 #[Group('ProductSource')]
@@ -28,7 +29,7 @@ class CreateHandler extends Handlers
     /**
      * Create Product Source
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(CreateProductSourceRequest $request)
     {

--- a/app/Filament/Resources/ProductSourceResource/Api/Handlers/DeleteHandler.php
+++ b/app/Filament/Resources/ProductSourceResource/Api/Handlers/DeleteHandler.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\ProductSourceResource\Api\Handlers;
 
 use App\Filament\Resources\ProductSourceResource;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Gate;
 use Rupadana\ApiService\Http\Handlers;
@@ -28,7 +29,7 @@ class DeleteHandler extends Handlers
     /**
      * Delete Product Source
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(Request $request)
     {

--- a/app/Filament/Resources/ProductSourceResource/Api/Handlers/UpdateHandler.php
+++ b/app/Filament/Resources/ProductSourceResource/Api/Handlers/UpdateHandler.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\ProductSourceResource\Api\Handlers;
 use App\Filament\Resources\ProductSourceResource;
 use App\Filament\Resources\ProductSourceResource\Api\Requests\UpdateProductSourceRequest;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Rupadana\ApiService\Http\Handlers;
 
 #[Group('ProductSource')]
@@ -27,7 +28,7 @@ class UpdateHandler extends Handlers
     /**
      * Update Product Source
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(UpdateProductSourceRequest $request)
     {

--- a/app/Filament/Resources/ProductSourceResource/Api/Requests/CreateProductSourceRequest.php
+++ b/app/Filament/Resources/ProductSourceResource/Api/Requests/CreateProductSourceRequest.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\ProductSourceResource\Api\Requests;
 use App\Enums\ProductSourceStatus;
 use App\Enums\ProductSourceType;
 use App\Rules\ContainsSearchTermPlaceholder;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class CreateProductSourceRequest extends FormRequest
@@ -20,7 +21,7 @@ class CreateProductSourceRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Filament/Resources/ProductSourceResource/Api/Requests/UpdateProductSourceRequest.php
+++ b/app/Filament/Resources/ProductSourceResource/Api/Requests/UpdateProductSourceRequest.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\ProductSourceResource\Api\Requests;
 use App\Enums\ProductSourceStatus;
 use App\Enums\ProductSourceType;
 use App\Rules\ContainsSearchTermPlaceholder;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateProductSourceRequest extends FormRequest
@@ -20,7 +21,7 @@ class UpdateProductSourceRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Filament/Resources/ProductSourceResource/Api/Transformers/ProductSourceResultsTransformer.php
+++ b/app/Filament/Resources/ProductSourceResource/Api/Transformers/ProductSourceResultsTransformer.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\ProductSourceResource\Api\Transformers;
 
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
@@ -14,7 +15,7 @@ class ProductSourceResultsTransformer extends JsonResource
     /**
      * Search for product via the product source.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      */
     public function toArray($request)
     {

--- a/app/Filament/Resources/ProductSourceResource/Api/Transformers/ProductSourceTransformer.php
+++ b/app/Filament/Resources/ProductSourceResource/Api/Transformers/ProductSourceTransformer.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\ProductSourceResource\Api\Transformers;
 use App\Http\Resources\StoreResource;
 use App\Http\Resources\UserResource;
 use App\Models\ProductSource;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
@@ -15,7 +16,7 @@ class ProductSourceTransformer extends JsonResource
     /**
      * Transform the resource into an array.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return array
      */
     public function toArray($request)

--- a/app/Filament/Resources/StoreResource.php
+++ b/app/Filament/Resources/StoreResource.php
@@ -55,7 +55,7 @@ class StoreResource extends Resource
     {
         return $form
             ->schema([
-                Forms\Components\Section::make('Basics')->schema([
+                Section::make('Basics')->schema([
                     TextInput::make('name')
                         ->label('Name')
                         ->hintIcon(Icons::Help->value, 'The name of the store')
@@ -65,7 +65,7 @@ class StoreResource extends Resource
                     ->description(__('Stores are shared between all users in :name', ['name' => config('app.name')]))
                     ->live(),
 
-                Forms\Components\Section::make('Domains')->schema([
+                Section::make('Domains')->schema([
                     Forms\Components\Repeater::make('domains')
                         ->schema([
                             TextInput::make('domain')->label('Domain'),
@@ -74,18 +74,18 @@ class StoreResource extends Resource
                     ->description('What domains does this store apply to'),
 
                 Forms\Components\Group::make([
-                    Forms\Components\Section::make('Title strategy')->schema([
+                    Section::make('Title strategy')->schema([
                         Forms\Components\Group::make(self::makeStrategyInput('title', self::DEFAULT_SELECTORS['title']))->columns(2),
                     ])->description('How to get the product title'),
-                    Forms\Components\Section::make('Price strategy')->schema([
+                    Section::make('Price strategy')->schema([
                         Forms\Components\Group::make(self::makeStrategyInput('price', self::DEFAULT_SELECTORS['price']))->columns(2),
                     ])->description('How to get the product price'),
-                    Forms\Components\Section::make('Image strategy')->schema([
+                    Section::make('Image strategy')->schema([
                         Forms\Components\Group::make(self::makeStrategyInput('image', self::DEFAULT_SELECTORS['image']))->columns(2),
                     ])->description('How to get the product image'),
-                    Forms\Components\Section::make('Availability strategy')->schema([
+                    Section::make('Availability strategy')->schema([
                         Forms\Components\Group::make(self::makeStrategyInput('availability', required: false))->columns(2),
-                        Forms\Components\Section::make('Match values')
+                        Section::make('Match values')
                             ->schema(
                                 collect(StockStatus::nonInStockCases())->map(
                                     fn (StockStatus $status) => Forms\Components\Group::make([
@@ -131,13 +131,13 @@ class StoreResource extends Resource
                     ->columns(2)
                     ->schema(AppSettingsPage::getLocaleFormFields('settings.locale_settings')),
 
-                Forms\Components\Section::make('Cookies')->schema([
+                Section::make('Cookies')->schema([
                     TextInput::make('cookies')
                         ->label('Cookies')
                         ->hintIcon(Icons::Help->value, 'Any cookies to include in scrape requests for this store. Format as you would in an HTTP header, e.g. "cookie1=value; cookie2=value"'),
                 ])->description('Optional cookies to include in scrape requests for this store'),
 
-                Forms\Components\Section::make('Notes')->schema([
+                Section::make('Notes')->schema([
                     Forms\Components\RichEditor::make('notes')
                         ->hiddenLabel(true),
                 ])->description('Additional notes regarding this store and how to scrape its content'),
@@ -148,7 +148,7 @@ class StoreResource extends Resource
     public static function testForm(Form $form): Form
     {
         return $form->schema([
-            Forms\Components\Section::make('Test url scrape')->schema([
+            Section::make('Test url scrape')->schema([
                 TextInput::make('test_url')
                     ->label('Product URL')
                     ->hintIcon(Icons::Help->value, 'The URL to scrape')

--- a/app/Filament/Resources/StoreResource/Api/Handlers/CreateHandler.php
+++ b/app/Filament/Resources/StoreResource/Api/Handlers/CreateHandler.php
@@ -7,6 +7,7 @@ use App\Filament\Resources\StoreResource;
 use App\Filament\Resources\StoreResource\Api\Requests\CreateStoreRequest;
 use App\Filament\Resources\StoreResource\Api\Transformers\StoreTransformer;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Rupadana\ApiService\Http\Handlers;
 
 #[Group(StoreResource::API_GROUP)]
@@ -29,7 +30,7 @@ class CreateHandler extends Handlers
     /**
      * Create Store
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(CreateStoreRequest $request)
     {

--- a/app/Filament/Resources/StoreResource/Api/Handlers/DeleteHandler.php
+++ b/app/Filament/Resources/StoreResource/Api/Handlers/DeleteHandler.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\StoreResource\Api\Handlers;
 
 use App\Filament\Resources\StoreResource;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Rupadana\ApiService\Http\Handlers;
 
@@ -27,7 +28,7 @@ class DeleteHandler extends Handlers
     /**
      * Delete Store
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(Request $request)
     {

--- a/app/Filament/Resources/StoreResource/Api/Handlers/UpdateHandler.php
+++ b/app/Filament/Resources/StoreResource/Api/Handlers/UpdateHandler.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\StoreResource\Api\Handlers;
 use App\Filament\Resources\StoreResource;
 use App\Filament\Resources\StoreResource\Api\Requests\UpdateStoreRequest;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Rupadana\ApiService\Http\Handlers;
 
 #[Group(StoreResource::API_GROUP)]
@@ -27,7 +28,7 @@ class UpdateHandler extends Handlers
     /**
      * Update Store
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(UpdateStoreRequest $request)
     {

--- a/app/Filament/Resources/StoreResource/Api/Requests/CreateStoreRequest.php
+++ b/app/Filament/Resources/StoreResource/Api/Requests/CreateStoreRequest.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\StoreResource\Api\Requests;
 
 use App\Enums\ScraperService;
 use App\Enums\ScraperStrategyType;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class CreateStoreRequest extends FormRequest
@@ -19,7 +20,7 @@ class CreateStoreRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Filament/Resources/StoreResource/Api/Requests/UpdateStoreRequest.php
+++ b/app/Filament/Resources/StoreResource/Api/Requests/UpdateStoreRequest.php
@@ -2,6 +2,9 @@
 
 namespace App\Filament\Resources\StoreResource\Api\Requests;
 
+use App\Enums\ScraperService;
+use App\Enums\ScraperStrategyType;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateStoreRequest extends FormRequest
@@ -17,7 +20,7 @@ class UpdateStoreRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {
@@ -28,16 +31,16 @@ class UpdateStoreRequest extends FormRequest
             'domains' => 'sometimes|array',
             'domains.*.domain' => 'required_with:domains|string',
             'settings' => 'sometimes|array',
-            'settings.scraper_service' => 'sometimes|in:'.implode(',', \App\Enums\ScraperService::values()),
+            'settings.scraper_service' => 'sometimes|in:'.implode(',', ScraperService::values()),
             'settings.scraper_service_settings' => 'nullable|string',
             'settings.locale_settings.locale' => 'sometimes|string',
             'settings.locale_settings.currency' => 'sometimes|string',
             'scrape_strategy' => 'sometimes|array',
-            'scrape_strategy.image.type' => 'sometimes|in:'.implode(',', \App\Enums\ScraperStrategyType::values()),
+            'scrape_strategy.image.type' => 'sometimes|in:'.implode(',', ScraperStrategyType::values()),
             'scrape_strategy.image.value' => 'required_with:scrape_strategy.image.type|string',
-            'scrape_strategy.price.type' => 'sometimes|in:'.implode(',', \App\Enums\ScraperStrategyType::values()),
+            'scrape_strategy.price.type' => 'sometimes|in:'.implode(',', ScraperStrategyType::values()),
             'scrape_strategy.price.value' => 'required_with:scrape_strategy.price.type|string',
-            'scrape_strategy.title.type' => 'sometimes|in:'.implode(',', \App\Enums\ScraperStrategyType::values()),
+            'scrape_strategy.title.type' => 'sometimes|in:'.implode(',', ScraperStrategyType::values()),
             'scrape_strategy.title.value' => 'required_with:scrape_strategy.title.type|string',
             'notes' => 'sometimes|string',
             'user_id' => 'sometimes|exists:users,id|in:'.auth()->id(),

--- a/app/Filament/Resources/StoreResource/Api/Transformers/StoreTransformer.php
+++ b/app/Filament/Resources/StoreResource/Api/Transformers/StoreTransformer.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\ProductResource\Api\Transformers\ProductTransformer;
 use App\Http\Resources\UrlResource;
 use App\Http\Resources\UserResource;
 use App\Models\Store;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
@@ -16,7 +17,7 @@ class StoreTransformer extends JsonResource
     /**
      * Transform the resource into an array.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      *
      * @SuppressWarnings("UnusedFormalParameter")
      *

--- a/app/Filament/Resources/TagResource/Api/Handlers/CreateHandler.php
+++ b/app/Filament/Resources/TagResource/Api/Handlers/CreateHandler.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\TagResource;
 use App\Filament\Resources\TagResource\Api\Requests\CreateTagRequest;
 use App\Filament\Resources\TagResource\Api\Transformers\TagTransformer;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Rupadana\ApiService\Http\Handlers;
 
 #[Group(TagResource::API_GROUP)]
@@ -28,7 +29,7 @@ class CreateHandler extends Handlers
     /**
      * Create Tag
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(CreateTagRequest $request)
     {

--- a/app/Filament/Resources/TagResource/Api/Handlers/DeleteHandler.php
+++ b/app/Filament/Resources/TagResource/Api/Handlers/DeleteHandler.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\TagResource\Api\Handlers;
 
 use App\Filament\Resources\TagResource;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Rupadana\ApiService\Http\Handlers;
 
@@ -27,7 +28,7 @@ class DeleteHandler extends Handlers
     /**
      * Delete Tag
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(Request $request)
     {

--- a/app/Filament/Resources/TagResource/Api/Handlers/UpdateHandler.php
+++ b/app/Filament/Resources/TagResource/Api/Handlers/UpdateHandler.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\TagResource\Api\Handlers;
 use App\Filament\Resources\TagResource;
 use App\Filament\Resources\TagResource\Api\Requests\UpdateTagRequest;
 use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Http\JsonResponse;
 use Rupadana\ApiService\Http\Handlers;
 
 #[Group(TagResource::API_GROUP)]
@@ -27,7 +28,7 @@ class UpdateHandler extends Handlers
     /**
      * Update Tag
      *
-     * @return \Illuminate\Http\JsonResponse
+     * @return JsonResponse
      */
     public function handler(UpdateTagRequest $request)
     {

--- a/app/Filament/Resources/TagResource/Api/Requests/CreateTagRequest.php
+++ b/app/Filament/Resources/TagResource/Api/Requests/CreateTagRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\TagResource\Api\Requests;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class CreateTagRequest extends FormRequest
@@ -19,7 +20,7 @@ class CreateTagRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Filament/Resources/TagResource/Api/Requests/UpdateTagRequest.php
+++ b/app/Filament/Resources/TagResource/Api/Requests/UpdateTagRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Resources\TagResource\Api\Requests;
 
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateTagRequest extends FormRequest
@@ -17,7 +18,7 @@ class UpdateTagRequest extends FormRequest
     /**
      * Get the validation rules that apply to the request.
      *
-     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     * @return array<string, ValidationRule|array<mixed>|string>
      */
     public function rules(): array
     {

--- a/app/Filament/Resources/TagResource/Api/Transformers/TagTransformer.php
+++ b/app/Filament/Resources/TagResource/Api/Transformers/TagTransformer.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\TagResource\Api\Transformers;
 
 use App\Models\Tag;
+use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
@@ -13,7 +14,7 @@ class TagTransformer extends JsonResource
     /**
      * Transform the resource into an array.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  Request  $request
      * @return array
      */
     public function toArray($request)

--- a/app/Models/Price.php
+++ b/app/Models/Price.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Events\PriceCreatedEvent;
 use Carbon\Carbon;
+use Database\Factories\UrlFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -20,7 +21,7 @@ use Illuminate\Database\Eloquent\Relations\HasOneThrough;
  */
 class Price extends Model
 {
-    /** @use HasFactory<\Database\Factories\UrlFactory> */
+    /** @use HasFactory<UrlFactory> */
     use HasFactory;
 
     protected $guarded = [];

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -10,6 +10,7 @@ use App\Filament\Actions\BaseAction;
 use App\Services\Helpers\CurrencyHelper;
 use App\Services\ScrapeUrl;
 use Carbon\Carbon;
+use Database\Factories\ProductFactory;
 use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
@@ -53,7 +54,7 @@ use Illuminate\Support\Str;
  */
 class Product extends Model
 {
-    /** @use HasFactory<\Database\Factories\ProductFactory> */
+    /** @use HasFactory<ProductFactory> */
     use HasFactory;
 
     protected $guarded = [
@@ -393,7 +394,7 @@ class Product extends Model
         $history = $this->getPriceHistory();
 
         // Include out-of-stock URLs that have no price history (e.g. price 0).
-        /** @var \Illuminate\Database\Eloquent\Collection<int, Url> $outOfStockUrls */
+        /** @var EloquentCollection<int, Url> $outOfStockUrls */
         $outOfStockUrls = $this->urls()
             ->whereNotNull('availability')
             ->whereNotIn('id', $history->keys())

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\ScraperService;
 use App\Services\Helpers\CurrencyHelper;
+use Database\Factories\StoreFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -36,7 +37,7 @@ use Spatie\Sluggable\SlugOptions;
  */
 class Store extends Model
 {
-    /** @use HasFactory<\Database\Factories\StoreFactory> */
+    /** @use HasFactory<StoreFactory> */
     use HasFactory;
 
     use HasSlug;

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use Database\Factories\TagFactory;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -13,7 +14,7 @@ use Illuminate\Database\Eloquent\Relations\MorphToMany;
  */
 class Tag extends Model
 {
-    /** @use HasFactory<\Database\Factories\TagFactory> */
+    /** @use HasFactory<TagFactory> */
     use HasFactory;
 
     protected $guarded = [];

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -8,6 +8,7 @@ use App\Services\Helpers\AffiliateHelper;
 use App\Services\Helpers\CurrencyHelper;
 use App\Services\ScrapeUrl;
 use Carbon\Carbon;
+use Database\Factories\UrlFactory;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -39,7 +40,7 @@ use Illuminate\Support\Str;
  */
 class Url extends Model
 {
-    /** @use HasFactory<\Database\Factories\UrlFactory> */
+    /** @use HasFactory<UrlFactory> */
     use HasFactory;
 
     public static function booted()

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -221,6 +221,7 @@ class Url extends Model
         }
 
         $availabilityChanged = false;
+        $stockStatus = null;
 
         if (is_null($price) || $price === '') {
             $scrapeResult = $scrapeResult ?? $this->scrape();
@@ -244,6 +245,15 @@ class Url extends Model
         if (is_null($price) || $price === '') {
             if ($availabilityChanged) {
                 $this->product?->updatePriceCache();
+            }
+
+            // An out-of-stock product with no scraped price is the expected
+            // outcome, not a failure. Keep the existing price history (we
+            // don't insert a new row) and return the latest known Price so
+            // the parent `Product::updatePrices()` doesn't count this URL
+            // as failed and trigger a scrape-error notification.
+            if ($stockStatus?->isUnavailable()) {
+                return $this->prices()->latest('id')->first();
             }
 
             return null;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\NotificationMethods;
+use Database\Factories\UserFactory;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Panel;
 use Filament\Panel\Concerns\HasNotifications;
@@ -19,7 +20,7 @@ use Laravel\Sanctum\HasApiTokens;
  */
 class User extends Authenticatable implements FilamentUser
 {
-    /** @use HasFactory<\Database\Factories\UserFactory> */
+    /** @use HasFactory<UserFactory> */
     use HasApiTokens, HasFactory, HasNotifications, Notifiable;
 
     /**

--- a/app/Rules/ContainsSearchTermPlaceholder.php
+++ b/app/Rules/ContainsSearchTermPlaceholder.php
@@ -4,13 +4,14 @@ namespace App\Rules;
 
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Translation\PotentiallyTranslatedString;
 
 class ContainsSearchTermPlaceholder implements ValidationRule
 {
     /**
      * Run the validation rule.
      *
-     * @param  \Closure(string, ?string=): \Illuminate\Translation\PotentiallyTranslatedString  $fail
+     * @param  Closure(string, ?string=): PotentiallyTranslatedString  $fail
      */
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {

--- a/app/Services/AutoCreateStore.php
+++ b/app/Services/AutoCreateStore.php
@@ -261,7 +261,7 @@ class AutoCreateStore
             }
 
             try {
-                preg_match_all($regex, $this->html, $matches);
+                preg_match_all(ScrapeUrl::ensureRegexDelimiters($regex), $this->html, $matches);
                 $extracted = data_get($matches, '1.0');
 
                 $value = is_null($validateValue)

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -233,6 +233,13 @@ class ScrapeUrl
             return null;
         }
 
+        // A strategy slot can have its type set but value left null; the scraper
+        // methods (getRegex, getSelector, ...) are typed `string`, so skip rather
+        // than passing null and triggering a TypeError. SchemaOrg ignores value.
+        if (! is_string($value) && $type !== ScraperStrategyType::SchemaOrg->value) {
+            return null;
+        }
+
         $method = self::getMethodFromType($type);
 
         $value = match ($type) {
@@ -286,10 +293,7 @@ class ScrapeUrl
             return $regex;
         }
 
-        $first = $regex[0];
-
-        // First char is a valid PHP regex delimiter — assume already delimited.
-        if (! ctype_alnum($first) && $first !== '\\' && ! ctype_space($first)) {
+        if (self::hasMatchingDelimiters($regex)) {
             return $regex;
         }
 
@@ -300,6 +304,44 @@ class ScrapeUrl
         }
 
         return '#'.str_replace('#', '\\#', $regex).'#';
+    }
+
+    /**
+     * Determine whether a pattern is already wrapped in valid PHP regex delimiters.
+     *
+     * Accepts a known single-char delimiter (/ # ~ % @ ! |) repeated at the end, or
+     * an opening paired delimiter ( { [ < closed by its partner ) } ] > — in either
+     * case optionally followed by valid modifier letters. A bare pattern that merely
+     * starts with a non-alphanumeric char (e.g. `$([0-9.]+)`) is NOT treated as
+     * delimited, so it gets wrapped instead of failing preg_* silently.
+     */
+    private static function hasMatchingDelimiters(string $regex): bool
+    {
+        if (strlen($regex) < 2) {
+            return false;
+        }
+
+        $paired = ['(' => ')', '{' => '}', '[' => ']', '<' => '>'];
+        $single = ['/', '#', '~', '%', '@', '!', '|'];
+
+        $first = $regex[0];
+
+        if (isset($paired[$first])) {
+            $closing = $paired[$first];
+        } elseif (in_array($first, $single, true)) {
+            $closing = $first;
+        } else {
+            return false;
+        }
+
+        // Walk back over trailing modifier letters to find the closing delimiter.
+        $index = strlen($regex) - 1;
+        while ($index > 0 && str_contains('imsxADSUXJun', $regex[$index])) {
+            $index--;
+        }
+
+        // The closing delimiter must sit past the opening one (non-empty body).
+        return $index >= 1 && $regex[$index] === $closing;
     }
 
     public static function parseSelector(string $selector): array

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -237,6 +237,7 @@ class ScrapeUrl
 
         $value = match ($type) {
             ScraperStrategyType::Selector->value => self::parseSelector($value),
+            ScraperStrategyType::Regex->value => [self::ensureRegexDelimiters($value)],
             default => [$value]
         };
 
@@ -270,6 +271,35 @@ class ScrapeUrl
             ScraperStrategyType::SchemaOrg->value => 'getSchemaOrg',
             default => 'getSelector'
         };
+    }
+
+    /**
+     * Wrap a user-supplied regex pattern in delimiters if it doesn't already have them.
+     *
+     * PHP's preg_* functions require pattern delimiters; bare patterns saved in the
+     * store strategy config (e.g. `https?://schema.org/(\w+)`) raise a warning and
+     * silently return no matches. Picks a delimiter that does not appear in the pattern.
+     */
+    public static function ensureRegexDelimiters(string $regex): string
+    {
+        if ($regex === '') {
+            return $regex;
+        }
+
+        $first = $regex[0];
+
+        // First char is a valid PHP regex delimiter — assume already delimited.
+        if (! ctype_alnum($first) && $first !== '\\' && ! ctype_space($first)) {
+            return $regex;
+        }
+
+        foreach (['#', '~', '%', '@', '!'] as $delimiter) {
+            if (! str_contains($regex, $delimiter)) {
+                return $delimiter.$regex.$delimiter;
+            }
+        }
+
+        return '#'.str_replace('#', '\\#', $regex).'#';
     }
 
     public static function parseSelector(string $selector): array

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -229,10 +229,10 @@ class ScrapeUrl
         $type = data_get($options, 'type');
         $value = data_get($options, 'value');
 
-        if (empty($value)) {
-        return null;
+        if (! is_string($type) || $type === '') {
+            return null;
         }
-        
+
         $method = self::getMethodFromType($type);
 
         $value = match ($type) {

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -1,6 +1,9 @@
 <?php
 
+use App\Providers\AppServiceProvider;
+use App\Providers\Filament\AdminPanelProvider;
+
 return [
-    App\Providers\AppServiceProvider::class,
-    App\Providers\Filament\AdminPanelProvider::class,
+    AppServiceProvider::class,
+    AdminPanelProvider::class,
 ];

--- a/config/auth.php
+++ b/config/auth.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Models\User;
+
 return [
 
     /*
@@ -62,7 +64,7 @@ return [
     'providers' => [
         'users' => [
             'driver' => 'eloquent',
-            'model' => env('AUTH_MODEL', App\Models\User::class),
+            'model' => env('AUTH_MODEL', User::class),
         ],
 
         // 'users' => [

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -1,5 +1,8 @@
 <?php
 
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\ValidateCsrfToken;
+use Laravel\Sanctum\Http\Middleware\AuthenticateSession;
 use Laravel\Sanctum\Sanctum;
 
 return [
@@ -76,9 +79,9 @@ return [
     */
 
     'middleware' => [
-        'authenticate_session' => Laravel\Sanctum\Http\Middleware\AuthenticateSession::class,
-        'encrypt_cookies' => Illuminate\Cookie\Middleware\EncryptCookies::class,
-        'validate_csrf_token' => Illuminate\Foundation\Http\Middleware\ValidateCsrfToken::class,
+        'authenticate_session' => AuthenticateSession::class,
+        'encrypt_cookies' => EncryptCookies::class,
+        'validate_csrf_token' => ValidateCsrfToken::class,
     ],
 
 ];

--- a/config/settings.php
+++ b/config/settings.php
@@ -1,5 +1,12 @@
 <?php
 
+use Spatie\LaravelData\Data;
+use Spatie\LaravelSettings\SettingsCasts\DataCast;
+use Spatie\LaravelSettings\SettingsCasts\DateTimeInterfaceCast;
+use Spatie\LaravelSettings\SettingsCasts\DateTimeZoneCast;
+use Spatie\LaravelSettings\SettingsRepositories\DatabaseSettingsRepository;
+use Spatie\LaravelSettings\SettingsRepositories\RedisSettingsRepository;
+
 return [
 
     /*
@@ -35,13 +42,13 @@ return [
      */
     'repositories' => [
         'database' => [
-            'type' => Spatie\LaravelSettings\SettingsRepositories\DatabaseSettingsRepository::class,
+            'type' => DatabaseSettingsRepository::class,
             'model' => null,
             'table' => null,
             'connection' => null,
         ],
         'redis' => [
-            'type' => Spatie\LaravelSettings\SettingsRepositories\RedisSettingsRepository::class,
+            'type' => RedisSettingsRepository::class,
             'connection' => null,
             'prefix' => null,
         ],
@@ -72,10 +79,10 @@ return [
      * your settings class isn't a default PHP type.
      */
     'global_casts' => [
-        DateTimeInterface::class => Spatie\LaravelSettings\SettingsCasts\DateTimeInterfaceCast::class,
-        DateTimeZone::class => Spatie\LaravelSettings\SettingsCasts\DateTimeZoneCast::class,
+        DateTimeInterface::class => DateTimeInterfaceCast::class,
+        DateTimeZone::class => DateTimeZoneCast::class,
         //        Spatie\DataTransferObject\DataTransferObject::class => Spatie\LaravelSettings\SettingsCasts\DtoCast::class,
-        Spatie\LaravelData\Data::class => Spatie\LaravelSettings\SettingsCasts\DataCast::class,
+        Data::class => DataCast::class,
     ],
 
     /*

--- a/database/factories/PriceFactory.php
+++ b/database/factories/PriceFactory.php
@@ -3,11 +3,12 @@
 namespace Database\Factories;
 
 use App\Models\Store;
+use App\Models\Tag;
 use App\Models\Url;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tag>
+ * @extends Factory<Tag>
  */
 class PriceFactory extends Factory
 {

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -13,7 +13,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Product>
+ * @extends Factory<Product>
  */
 class ProductFactory extends Factory
 {

--- a/database/factories/ProductSourceFactory.php
+++ b/database/factories/ProductSourceFactory.php
@@ -4,12 +4,13 @@ namespace Database\Factories;
 
 use App\Enums\ProductSourceStatus;
 use App\Enums\ProductSourceType;
+use App\Models\ProductSource;
 use App\Models\Store;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\ProductSource>
+ * @extends Factory<ProductSource>
  */
 class ProductSourceFactory extends Factory
 {

--- a/database/factories/StoreFactory.php
+++ b/database/factories/StoreFactory.php
@@ -3,12 +3,13 @@
 namespace Database\Factories;
 
 use App\Enums\ScraperService;
+use App\Models\Store;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 use Illuminate\Support\Uri;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Store>
+ * @extends Factory<Store>
  */
 class StoreFactory extends Factory
 {

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -2,11 +2,12 @@
 
 namespace Database\Factories;
 
+use App\Models\Tag;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tag>
+ * @extends Factory<Tag>
  */
 class TagFactory extends Factory
 {

--- a/database/factories/UrlFactory.php
+++ b/database/factories/UrlFactory.php
@@ -9,7 +9,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Url>
+ * @extends Factory<Url>
  */
 class UrlFactory extends Factory
 {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -2,12 +2,13 @@
 
 namespace Database\Factories;
 
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Str;
 
 /**
- * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\User>
+ * @extends Factory<User>
  */
 class UserFactory extends Factory
 {

--- a/database/migrations/2025_04_23_094230_set_search_setting_defaults.php
+++ b/database/migrations/2025_04_23_094230_set_search_setting_defaults.php
@@ -5,6 +5,7 @@ use App\Models\UrlResearch;
 use App\Services\Helpers\IntegrationHelper;
 use App\Services\SearchService;
 use Illuminate\Database\Migrations\Migration;
+use Spatie\LaravelSettings\Exceptions\MissingSettings;
 
 return new class extends Migration
 {
@@ -20,7 +21,7 @@ return new class extends Migration
             data_set($settings, IntegratedServices::SearXng->value.'.max_pages', SearchService::DEFAULT_MAX_PAGES);
 
             IntegrationHelper::setSettings($settings);
-        } catch (\Spatie\LaravelSettings\Exceptions\MissingSettings $e) {
+        } catch (MissingSettings $e) {
             // Settings not fully migrated yet, skip this migration
             // It will be handled when settings are properly configured
         }

--- a/tests/Feature/Console/ConsoleCommandsTest.php
+++ b/tests/Feature/Console/ConsoleCommandsTest.php
@@ -14,6 +14,7 @@ use Database\Seeders\StoreSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 use Tests\TestCase;
 
 class ConsoleCommandsTest extends TestCase
@@ -87,7 +88,7 @@ class ConsoleCommandsTest extends TestCase
         if (! empty($storeData)) {
             $firstStore = $storeData[0];
             Store::factory()->create([
-                'slug' => $firstStore['slug'] ?? \Illuminate\Support\Str::slug($firstStore['name']),
+                'slug' => $firstStore['slug'] ?? Str::slug($firstStore['name']),
                 'name' => $firstStore['name'],
             ]);
 
@@ -111,7 +112,7 @@ class ConsoleCommandsTest extends TestCase
         if (! empty($storeData)) {
             $firstStore = $storeData[0];
             $store = Store::factory()->create([
-                'slug' => $firstStore['slug'] ?? \Illuminate\Support\Str::slug($firstStore['name']),
+                'slug' => $firstStore['slug'] ?? Str::slug($firstStore['name']),
                 'name' => 'Old Name',
             ]);
 

--- a/tests/Feature/Models/UrlTest.php
+++ b/tests/Feature/Models/UrlTest.php
@@ -227,6 +227,89 @@ class UrlTest extends TestCase
         $this->assertSame(StockStatus::OutOfStock, $url->fresh()->availability);
     }
 
+    public function test_update_price_unavailable_with_existing_price_returns_latest_and_keeps_history()
+    {
+        // Regression: when a URL with an existing price history goes out of
+        // stock, `updatePrice` previously returned null. `Product::updatePrices`
+        // counts null returns as failures, which would surface as a "scrape
+        // error" on the product page for a product that is just out of stock.
+        // The latest known price should be returned so the parent doesn't
+        // consider this URL failed, and no new price row should be inserted.
+        $product = Product::factory()->create();
+        $url = Url::factory()->createOne([
+            'url' => self::TEST_URL,
+            'product_id' => $product->id,
+            'store_id' => $this->store->id,
+        ]);
+        /** @var Price $existing */
+        $existing = $url->prices()->create([
+            'price' => 12.5,
+            'unit_price' => 12.5,
+            'price_factor' => 1,
+            'store_id' => $this->store->id,
+        ]);
+
+        $this->store->update([
+            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+                'availability' => [
+                    'type' => 'selector',
+                    'value' => '.availability',
+                    'match' => [
+                        'out_of_stock' => ['type' => 'match', 'value' => 'OutOfStock'],
+                        'default' => 'in_stock',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $this->mockScrape('', 'foo', null, 'OutOfStock');
+
+        $priceModel = $url->updatePrice();
+
+        $this->assertInstanceOf(Price::class, $priceModel);
+        $this->assertSame($existing->id, $priceModel->id);
+        $this->assertCount(1, $url->fresh()->prices);
+        $this->assertSame(StockStatus::OutOfStock, $url->fresh()->availability);
+    }
+
+    public function test_product_update_prices_is_successful_when_only_url_goes_out_of_stock()
+    {
+        // Regression for the same path at the product level: a product with a
+        // single URL that goes out of stock should not be reported as a
+        // failed scrape (which fires ScrapeFailNotification + UI error).
+        $product = Product::factory()->create();
+        $url = Url::factory()->createOne([
+            'url' => self::TEST_URL,
+            'product_id' => $product->id,
+            'store_id' => $this->store->id,
+        ]);
+        $url->prices()->create([
+            'price' => 9.99,
+            'unit_price' => 9.99,
+            'price_factor' => 1,
+            'store_id' => $this->store->id,
+        ]);
+
+        $this->store->update([
+            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+                'availability' => [
+                    'type' => 'selector',
+                    'value' => '.availability',
+                    'match' => [
+                        'out_of_stock' => ['type' => 'match', 'value' => 'OutOfStock'],
+                        'default' => 'in_stock',
+                    ],
+                ],
+            ]),
+        ]);
+
+        $this->mockScrape('', 'foo', null, 'OutOfStock');
+
+        $successful = $product->fresh()->updatePrices();
+
+        $this->assertTrue($successful);
+    }
+
     public function test_update_price_unavailable_to_in_stock_creates_price_and_clears_availability()
     {
         $product = Product::factory()->create();

--- a/tests/Unit/Dto/PriceCacheDtoTest.php
+++ b/tests/Unit/Dto/PriceCacheDtoTest.php
@@ -200,4 +200,51 @@ class PriceCacheDtoTest extends TestCase
         $this->assertTrue($dto->isUnavailable());
         $this->assertSame(StockStatus::OutOfStock, $dto->getStockStatus());
     }
+
+    public function test_unavailable_url_is_considered_successfully_scraped_despite_stale_price_row()
+    {
+        // Regression: OOS URLs don't get new price rows inserted by
+        // Url::updatePrice, so last_scrape lags arbitrarily far behind.
+        // The "Scrape error" badge in the product UI is gated on
+        // isLastScrapeSuccessful(); without this guard an OOS product is
+        // permanently flagged as a scrape failure.
+        $dto = PriceCacheDto::fromArray([
+            'price' => 10.0,
+            'history' => [],
+            'availability' => StockStatus::OutOfStock->value,
+            'last_scrape' => now()->subMonths(3)->toDateTimeString(),
+            'locale' => 'en',
+            'currency' => 'USD',
+        ]);
+
+        $this->assertTrue($dto->isUnavailable());
+        $this->assertTrue($dto->isLastScrapeSuccessful());
+    }
+
+    public function test_in_stock_url_with_stale_price_row_is_unsuccessful()
+    {
+        $dto = PriceCacheDto::fromArray([
+            'price' => 10.0,
+            'history' => [],
+            'last_scrape' => now()->subDays(2)->toDateTimeString(),
+            'locale' => 'en',
+            'currency' => 'USD',
+        ]);
+
+        $this->assertFalse($dto->isUnavailable());
+        $this->assertFalse($dto->isLastScrapeSuccessful());
+    }
+
+    public function test_in_stock_url_with_recent_price_row_is_successful()
+    {
+        $dto = PriceCacheDto::fromArray([
+            'price' => 10.0,
+            'history' => [],
+            'last_scrape' => now()->subHours(2)->toDateTimeString(),
+            'locale' => 'en',
+            'currency' => 'USD',
+        ]);
+
+        $this->assertTrue($dto->isLastScrapeSuccessful());
+    }
 }

--- a/tests/Unit/Services/ScrapeUrlTest.php
+++ b/tests/Unit/Services/ScrapeUrlTest.php
@@ -129,6 +129,11 @@ class ScrapeUrlTest extends TestCase
             'tilde-delimited passes through' => ['~foo~', '~foo~'],
             'pattern containing # picks the next available delimiter' => ['fragment#section', '~fragment#section~'],
             'empty string is returned unchanged' => ['', ''],
+            'dollar-anchored bare pattern is wrapped, not treated as delimited' => ['$([0-9.]+)', '#$([0-9.]+)#'],
+            'single delimiter with no closing delimiter is wrapped' => ['/foo', '#/foo#'],
+            'paired parens delimiter passes through' => ['(\d+)', '(\d+)'],
+            'paired braces delimiter passes through' => ['{\d+}', '{\d+}'],
+            'bare char class with quantifier is wrapped' => ['[0-9]+', '#[0-9]+#'],
         ];
     }
 
@@ -186,6 +191,30 @@ class ScrapeUrlTest extends TestCase
         $result = ScrapeUrl::new(self::TEST_URL)->scrape();
 
         // Other fields scrape normally; availability is skipped (null).
+        $this->assertSame('Example Title', $result['title']);
+        $this->assertSame('$10.00', $result['price']);
+        $this->assertNull($result['availability']);
+    }
+
+    public function test_scrape_regex_strategy_with_null_value_does_not_throw()
+    {
+        // A regex strategy slot can have its `type` set but `value` left null.
+        // ensureRegexDelimiters() is typed `string`, so passing the null value
+        // straight through the Regex match arm raised an uncaught TypeError and
+        // failed the whole scrape. The arm now guards on is_string().
+        $this->store->update([
+            'scrape_strategy' => [
+                'title' => ['type' => 'selector', 'value' => 'meta[property=og:title]|content'],
+                'price' => ['type' => 'selector', 'value' => 'meta[property=og:price:amount]|content'],
+                'image' => ['type' => 'selector', 'value' => 'meta[property=og:image]|content'],
+                'availability' => ['type' => 'regex', 'value' => null],
+            ],
+        ]);
+
+        $this->mockScrape('$10.00', 'Example Title', 'https://example.com/x.png');
+
+        $result = ScrapeUrl::new(self::TEST_URL)->scrape();
+
         $this->assertSame('Example Title', $result['title']);
         $this->assertSame('$10.00', $result['price']);
         $this->assertNull($result['availability']);

--- a/tests/Unit/Services/ScrapeUrlTest.php
+++ b/tests/Unit/Services/ScrapeUrlTest.php
@@ -118,6 +118,50 @@ class ScrapeUrlTest extends TestCase
         $this->assertEquals('$10.00', $result['price']);
     }
 
+    public static function regexDelimiterCases(): array
+    {
+        return [
+            'bare alphanumeric start is wrapped' => ['https?://schema.org/(\w+)', '#https?://schema.org/(\w+)#'],
+            'bare backslash start is wrapped' => ['\d+', '#\d+#'],
+            'slash-delimited passes through' => ['/foo/', '/foo/'],
+            'slash-delimited with flags passes through' => ['/foo/i', '/foo/i'],
+            'hash-delimited passes through' => ['#https?://schema.org/(\w+)#', '#https?://schema.org/(\w+)#'],
+            'tilde-delimited passes through' => ['~foo~', '~foo~'],
+            'pattern containing # picks the next available delimiter' => ['fragment#section', '~fragment#section~'],
+            'empty string is returned unchanged' => ['', ''],
+        ];
+    }
+
+    /**
+     * @dataProvider regexDelimiterCases
+     */
+    public function test_ensure_regex_delimiters(string $input, string $expected)
+    {
+        $this->assertSame($expected, ScrapeUrl::ensureRegexDelimiters($input));
+    }
+
+    public function test_scrape_regex_strategy_accepts_bare_pattern()
+    {
+        // Store strategies historically saved availability as a bare regex
+        // (no delimiters), e.g. `https?://schema.org/(\w+)`. Without the fix,
+        // preg_match_all warns "Delimiter must not be alphanumeric" and the
+        // availability is silently null. This regression-tests that.
+        $this->store->update([
+            'scrape_strategy' => [
+                'title' => ['type' => 'selector', 'value' => 'meta[property=og:title]|content'],
+                'price' => ['type' => 'selector', 'value' => 'meta[property=og:price:amount]|content'],
+                'image' => ['type' => 'selector', 'value' => 'meta[property=og:image]|content'],
+                'availability' => ['type' => 'regex', 'value' => 'https?://schema.org/(\w+)'],
+            ],
+        ]);
+
+        $this->mockScrape('$10.00', 'Example Title', 'https://example.com/x.png', 'http://schema.org/OutOfStock');
+
+        $result = ScrapeUrl::new(self::TEST_URL)->scrape();
+
+        $this->assertSame('OutOfStock', $result['availability']);
+    }
+
     public function test_scrape_schema_org()
     {
         $this->store->update([

--- a/tests/Unit/Services/ScrapeUrlTest.php
+++ b/tests/Unit/Services/ScrapeUrlTest.php
@@ -162,6 +162,35 @@ class ScrapeUrlTest extends TestCase
         $this->assertSame('OutOfStock', $result['availability']);
     }
 
+    public function test_scrape_skips_strategy_entry_with_null_type()
+    {
+        // Real-world: a seeded store can have a strategy slot (e.g. availability)
+        // with the match table populated but `type` left null. Before the guard,
+        // this raised a TypeError in getMethodFromType and the whole scrape — for
+        // every field, not just availability — bailed with a 500.
+        $this->store->update([
+            'scrape_strategy' => [
+                'title' => ['type' => 'selector', 'value' => 'meta[property=og:title]|content'],
+                'price' => ['type' => 'selector', 'value' => 'meta[property=og:price:amount]|content'],
+                'image' => ['type' => 'selector', 'value' => 'meta[property=og:image]|content'],
+                'availability' => [
+                    'type' => null,
+                    'value' => null,
+                    'match' => ['default' => 'in_stock'],
+                ],
+            ],
+        ]);
+
+        $this->mockScrape('$10.00', 'Example Title', 'https://example.com/x.png');
+
+        $result = ScrapeUrl::new(self::TEST_URL)->scrape();
+
+        // Other fields scrape normally; availability is skipped (null).
+        $this->assertSame('Example Title', $result['title']);
+        $this->assertSame('$10.00', $result['price']);
+        $this->assertNull($result['availability']);
+    }
+
     public function test_scrape_schema_org()
     {
         $this->store->update([


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Out-of-stock products no longer mark scrapes as failures; existing price history is preserved when a URL becomes unavailable.
  * Regex-based scrape strategies now handle user-provided patterns more robustly by normalizing delimiters before matching.

* **Tests**
  * Added coverage for out-of-stock transitions and for regex delimiter/strategy edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->