### PR TITLE
Stop search after priced results

### DIFF
--- a/.ai/guidelines/general-preferences.blade.php
+++ b/.ai/guidelines/general-preferences.blade.php
@@ -2,6 +2,7 @@
 
 * Favour TDD when completing tasks, usually a test class exists for the task already, assume you have
   to make one if it doesn't exist.
+* Use phpunit style OO formatting when creating new tests.
 * After each major task, provide evidence of the test passing.
 * If the playwright mcp is available, use it! the base url is `http://price-buddy.lndo.site/admin`, login
   email: `test@test.com`, password: `password`. If user doesn't exist, seed UserSeder. Important for:
@@ -23,5 +24,5 @@
 
 ## Environment preferences
 
-* If a `guidelines.local.md` file exists use it! It may contain instructions for running
+* If a `guidelines.local.md` file exists, read it now! It may contain instructions for running
   commands in this environment.

--- a/app/Filament/Pages/AppSettingsPage.php
+++ b/app/Filament/Pages/AppSettingsPage.php
@@ -242,6 +242,13 @@ class AppSettingsPage extends SettingsPage
                     ->placeholder('Buy')
                     ->hintIcon(Icons::Help->value, __('Text to prepend to the product name when searching'))
                     ->nullable(),
+                TextInput::make('max_priced_results')
+                    ->label('Stop after this many priced results')
+                    ->hintIcon(Icons::Help->value, __('Search will stop once this many results with detected prices have been found'))
+                    ->numeric()
+                    ->minValue(1)
+                    ->required()
+                    ->default(SearchService::DEFAULT_MAX_PRICED_RESULTS),
                 Select::make('prune_days')
                     ->label('Cache duration')
                     ->required()

--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -80,7 +80,6 @@ class SearchService
                 ->normalizeStructure()
                 ->addStores()
                 ->hydrateWithScrapedData()
-                ->saveUrlResearch()
                 ->log('Completed research for: '.$searchQuery)
                 ->setIsComplete(true);
         } catch (Exception $e) {
@@ -96,22 +95,6 @@ class SearchService
     public function getResults(): Collection
     {
         return $this->results;
-    }
-
-    public function saveUrlResearch(): self
-    {
-        $this->log('Saving URL research');
-
-        $this->results->each(function ($result) {
-            UrlResearch::updateOrCreate(
-                ['url' => $result['url']],
-                collect($result)->only([
-                    'html', 'title', 'image', 'price', 'store_id', 'strategies', 'execution_time',
-                ])->all()
-            );
-        });
-
-        return $this;
     }
 
     public function getSearchUrl(): ?string

--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -9,6 +9,7 @@ use App\Models\Store;
 use App\Models\UrlResearch;
 use App\Services\Helpers\IntegrationHelper;
 use Exception;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
@@ -25,6 +26,8 @@ class SearchService
     public const int LOG_TTL_MINS = 60; // 1 hour
 
     public const int DEFAULT_MAX_PAGES = 1;
+
+    public const int DEFAULT_MAX_PRICED_RESULTS = 10;
 
     public Collection $results;
 
@@ -119,6 +122,14 @@ class SearchService
     public function getMaxPages(): int
     {
         return data_get(self::getSettings(), 'max_pages', self::DEFAULT_MAX_PAGES);
+    }
+
+    public function getMaxPricedResults(): int
+    {
+        return max(
+            1,
+            (int) data_get(self::getSettings(), 'max_priced_results', self::DEFAULT_MAX_PRICED_RESULTS)
+        );
     }
 
     public function getProductSourceResults(): self
@@ -261,30 +272,26 @@ class SearchService
         $this->log('Hydrating results');
 
         $existing = $this->getUrlResearch();
+        $maxPricedResults = $this->getMaxPricedResults();
+        $pricedResultsCount = 0;
+        $hydratedResults = collect();
 
-        $this->results = $this->results
-            ->map(function ($result) use ($existing) {
-                $logArgs = collect($result)->only(['title', 'url', 'domain'])->all();
+        foreach ($this->results as $result) {
+            $logArgs = collect($result)->only(['title', 'url', 'domain'])->all();
+            $cachedResult = $existing->get($result['url']);
 
-                if ($existing->get($result['url'])) {
-                    $this->log(__('Using cache ":title" (:domain)', $logArgs), ['subtitle' => $result['url'], 'icon' => Icons::Database->value]);
+            if ($cachedResult) {
+                $this->log(__('Using cache ":title" (:domain)', $logArgs), ['subtitle' => $result['url'], 'icon' => Icons::Database->value]);
 
-                    return $result;
-                }
-
+                $result = array_merge($result, Arr::only($cachedResult->toArray(), [
+                    'html', 'image', 'price', 'store_id', 'strategies', 'execution_time',
+                ]));
+            } else {
                 $timeStart = microtime(true);
                 $this->log(__('Analyzing ":title" (:domain)', $logArgs), ['subtitle' => $result['url']]);
 
                 try {
-                    $dto = new ProductResearchUrlDto(url: $result['url'], cached: true);
-
-                    $result = array_merge($result, [
-                        'price' => $dto->getPrice(),
-                        'image' => $dto->getImage(),
-                        'strategies' => $dto->getStrategies(),
-                        'is_product_page' => $dto->getIsProductPage()->value,
-                        'html' => $dto->getHtml(),
-                    ]);
+                    $result = array_merge($result, $this->getHydratedResultData($result));
 
                     if (! empty($result['price'])) {
                         $this->replaceLastLogEntry(__('Price found ":title" (:domain)', $logArgs));
@@ -297,11 +304,52 @@ class SearchService
                 }
 
                 $result['execution_time'] = (microtime(true) - $timeStart);
+            }
 
-                return $result;
-            });
+            $hydratedResults->push($result);
+            $this->persistUrlResearchResult($result);
+
+            if (empty($result['price'])) {
+                continue;
+            }
+
+            $pricedResultsCount++;
+
+            if ($pricedResultsCount < $maxPricedResults) {
+                continue;
+            }
+
+            $this->log(__('Stopping search after finding :count priced results', ['count' => $pricedResultsCount]));
+
+            break;
+        }
+
+        $this->results = $hydratedResults;
 
         return $this;
+    }
+
+    protected function getHydratedResultData(array $result): array
+    {
+        $dto = new ProductResearchUrlDto(url: $result['url'], cached: true);
+
+        return [
+            'price' => $dto->getPrice(),
+            'image' => $dto->getImage(),
+            'strategies' => $dto->getStrategies(),
+            'is_product_page' => $dto->getIsProductPage()->value,
+            'html' => $dto->getHtml(),
+        ];
+    }
+
+    protected function persistUrlResearchResult(array $result): void
+    {
+        UrlResearch::updateOrCreate(
+            ['url' => $result['url']],
+            collect($result)->only([
+                'html', 'title', 'image', 'price', 'store_id', 'strategies', 'execution_time',
+            ])->all()
+        );
     }
 
     public static function getSettings(): array

--- a/tests/Feature/Services/ProductSourceSearchServiceTest.php
+++ b/tests/Feature/Services/ProductSourceSearchServiceTest.php
@@ -1,30 +1,37 @@
 <?php
 
+namespace Tests\Feature\Services;
+
 use App\Models\ProductSource;
 use App\Services\ProductSourceSearchService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-uses(RefreshDatabase::class, TestCase::class);
+class ProductSourceSearchServiceTest extends TestCase
+{
+    use RefreshDatabase;
 
-it('replaces search_term placeholder in url', function () {
-    $source = ProductSource::factory()->make([
-        'search_url' => 'https://example.com/search?q=:search_term',
-    ]);
+    public function test_replaces_search_term_placeholder_in_url()
+    {
+        $source = ProductSource::factory()->make([
+            'search_url' => 'https://example.com/search?q=:search_term',
+        ]);
 
-    $service = ProductSourceSearchService::new($source);
-    $url = $service->buildSearchUrl('laptop');
+        $service = ProductSourceSearchService::new($source);
+        $url = $service->buildSearchUrl('laptop');
 
-    expect($url)->toBe('https://example.com/search?q=laptop');
-});
+        $this->assertSame('https://example.com/search?q=laptop', $url);
+    }
 
-it('url encodes the search term', function () {
-    $source = ProductSource::factory()->make([
-        'search_url' => 'https://example.com/search?q=:search_term',
-    ]);
+    public function test_url_encodes_the_search_term()
+    {
+        $source = ProductSource::factory()->make([
+            'search_url' => 'https://example.com/search?q=:search_term',
+        ]);
 
-    $service = ProductSourceSearchService::new($source);
-    $url = $service->buildSearchUrl('gaming laptop');
+        $service = ProductSourceSearchService::new($source);
+        $url = $service->buildSearchUrl('gaming laptop');
 
-    expect($url)->toBe('https://example.com/search?q=gaming+laptop');
-});
+        $this->assertSame('https://example.com/search?q=gaming+laptop', $url);
+    }
+}

--- a/tests/Feature/Services/SearchServiceTest.php
+++ b/tests/Feature/Services/SearchServiceTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Models\UrlResearch;
-use App\Services\Helpers\IntegrationHelper;
 use App\Services\SearchService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -9,14 +8,13 @@ use Tests\TestCase;
 uses(RefreshDatabase::class, TestCase::class);
 
 it('stops hydrating after the configured number of priced results', function () {
-    IntegrationHelper::setSettings([
-        'searxng' => [
-            'max_priced_results' => 2,
-        ],
-    ]);
-
     $service = new class('laptop') extends SearchService
     {
+        public function getMaxPricedResults(): int
+        {
+            return 2;
+        }
+
         protected function getHydratedResultData(array $result): array
         {
             $price = match ($result['url']) {
@@ -43,7 +41,19 @@ it('stops hydrating after the configured number of priced results', function () 
         ['title' => 'Four', 'url' => 'https://example.com/priced-3', 'domain' => 'example.com'],
     ]);
 
+    $savedUrls = [];
+    UrlResearch::saved(function (UrlResearch $research) use (&$savedUrls) {
+        $savedUrls[] = $research->url;
+    });
+
     $service->hydrateWithScrapedData();
+
+    // Each processed result must be persisted exactly once (guards against double hydration/persistence).
+    expect($savedUrls)->toBe([
+        'https://example.com/priced-1',
+        'https://example.com/no-price',
+        'https://example.com/priced-2',
+    ]);
 
     expect($service->results->pluck('url')->all())->toBe([
         'https://example.com/priced-1',

--- a/tests/Feature/Services/SearchServiceTest.php
+++ b/tests/Feature/Services/SearchServiceTest.php
@@ -1,71 +1,77 @@
 <?php
 
+namespace Tests\Feature\Services;
+
 use App\Models\UrlResearch;
 use App\Services\SearchService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
-uses(RefreshDatabase::class, TestCase::class);
+class SearchServiceTest extends TestCase
+{
+    use RefreshDatabase;
 
-it('stops hydrating after the configured number of priced results', function () {
-    $service = new class('laptop') extends SearchService
+    public function test_stops_hydrating_after_the_configured_number_of_priced_results()
     {
-        public function getMaxPricedResults(): int
+        $service = new class('laptop') extends SearchService
         {
-            return 2;
-        }
+            public function getMaxPricedResults(): int
+            {
+                return 2;
+            }
 
-        protected function getHydratedResultData(array $result): array
-        {
-            $price = match ($result['url']) {
-                'https://example.com/priced-1' => 100.0,
-                'https://example.com/priced-2' => 200.0,
-                'https://example.com/priced-3' => 300.0,
-                default => null,
-            };
+            protected function getHydratedResultData(array $result): array
+            {
+                $price = match ($result['url']) {
+                    'https://example.com/priced-1' => 100.0,
+                    'https://example.com/priced-2' => 200.0,
+                    'https://example.com/priced-3' => 300.0,
+                    default => null,
+                };
 
-            return [
-                'price' => $price,
-                'image' => null,
-                'strategies' => [],
-                'is_product_page' => null,
-                'html' => null,
-            ];
-        }
-    };
+                return [
+                    'price' => $price,
+                    'image' => null,
+                    'strategies' => [],
+                    'is_product_page' => null,
+                    'html' => null,
+                ];
+            }
+        };
 
-    $service->results = collect([
-        ['title' => 'One', 'url' => 'https://example.com/priced-1', 'domain' => 'example.com'],
-        ['title' => 'Two', 'url' => 'https://example.com/no-price', 'domain' => 'example.com'],
-        ['title' => 'Three', 'url' => 'https://example.com/priced-2', 'domain' => 'example.com'],
-        ['title' => 'Four', 'url' => 'https://example.com/priced-3', 'domain' => 'example.com'],
-    ]);
+        $service->results = collect([
+            ['title' => 'One', 'url' => 'https://example.com/priced-1', 'domain' => 'example.com'],
+            ['title' => 'Two', 'url' => 'https://example.com/no-price', 'domain' => 'example.com'],
+            ['title' => 'Three', 'url' => 'https://example.com/priced-2', 'domain' => 'example.com'],
+            ['title' => 'Four', 'url' => 'https://example.com/priced-3', 'domain' => 'example.com'],
+        ]);
 
-    $savedUrls = [];
-    UrlResearch::saved(function (UrlResearch $research) use (&$savedUrls) {
-        $savedUrls[] = $research->url;
-    });
+        $savedUrls = [];
+        UrlResearch::saved(function (UrlResearch $research) use (&$savedUrls) {
+            $savedUrls[] = $research->url;
+        });
 
-    $service->hydrateWithScrapedData();
+        $service->hydrateWithScrapedData();
 
-    // Each processed result must be persisted exactly once (guards against double hydration/persistence).
-    expect($savedUrls)->toBe([
-        'https://example.com/priced-1',
-        'https://example.com/no-price',
-        'https://example.com/priced-2',
-    ]);
+        // Each processed result must be persisted exactly once (guards against double hydration/persistence).
+        $this->assertSame([
+            'https://example.com/priced-1',
+            'https://example.com/no-price',
+            'https://example.com/priced-2',
+        ], $savedUrls);
 
-    expect($service->results->pluck('url')->all())->toBe([
-        'https://example.com/priced-1',
-        'https://example.com/no-price',
-        'https://example.com/priced-2',
-    ]);
+        $this->assertSame([
+            'https://example.com/priced-1',
+            'https://example.com/no-price',
+            'https://example.com/priced-2',
+        ], $service->results->pluck('url')->all());
 
-    expect(UrlResearch::query()->orderBy('id')->pluck('url')->all())->toBe([
-        'https://example.com/priced-1',
-        'https://example.com/no-price',
-        'https://example.com/priced-2',
-    ]);
+        $this->assertSame([
+            'https://example.com/priced-1',
+            'https://example.com/no-price',
+            'https://example.com/priced-2',
+        ], UrlResearch::query()->orderBy('id')->pluck('url')->all());
 
-    expect(UrlResearch::query()->whereNotNull('price')->count())->toBe(2);
-});
+        $this->assertSame(2, UrlResearch::query()->whereNotNull('price')->count());
+    }
+}

--- a/tests/Feature/Services/SearchServiceTest.php
+++ b/tests/Feature/Services/SearchServiceTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Models\UrlResearch;
+use App\Services\Helpers\IntegrationHelper;
+use App\Services\SearchService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+uses(RefreshDatabase::class, TestCase::class);
+
+it('stops hydrating after the configured number of priced results', function () {
+    IntegrationHelper::setSettings([
+        'searxng' => [
+            'max_priced_results' => 2,
+        ],
+    ]);
+
+    $service = new class('laptop') extends SearchService
+    {
+        protected function getHydratedResultData(array $result): array
+        {
+            $price = match ($result['url']) {
+                'https://example.com/priced-1' => 100.0,
+                'https://example.com/priced-2' => 200.0,
+                'https://example.com/priced-3' => 300.0,
+                default => null,
+            };
+
+            return [
+                'price' => $price,
+                'image' => null,
+                'strategies' => [],
+                'is_product_page' => null,
+                'html' => null,
+            ];
+        }
+    };
+
+    $service->results = collect([
+        ['title' => 'One', 'url' => 'https://example.com/priced-1', 'domain' => 'example.com'],
+        ['title' => 'Two', 'url' => 'https://example.com/no-price', 'domain' => 'example.com'],
+        ['title' => 'Three', 'url' => 'https://example.com/priced-2', 'domain' => 'example.com'],
+        ['title' => 'Four', 'url' => 'https://example.com/priced-3', 'domain' => 'example.com'],
+    ]);
+
+    $service->hydrateWithScrapedData();
+
+    expect($service->results->pluck('url')->all())->toBe([
+        'https://example.com/priced-1',
+        'https://example.com/no-price',
+        'https://example.com/priced-2',
+    ]);
+
+    expect(UrlResearch::query()->pluck('url')->all())->toBe([
+        'https://example.com/priced-1',
+        'https://example.com/no-price',
+        'https://example.com/priced-2',
+    ]);
+
+    expect(UrlResearch::query()->whereNotNull('price')->count())->toBe(2);
+});

--- a/tests/Feature/Services/SearchServiceTest.php
+++ b/tests/Feature/Services/SearchServiceTest.php
@@ -51,7 +51,7 @@ it('stops hydrating after the configured number of priced results', function () 
         'https://example.com/priced-2',
     ]);
 
-    expect(UrlResearch::query()->pluck('url')->all())->toBe([
+    expect(UrlResearch::query()->orderBy('id')->pluck('url')->all())->toBe([
         'https://example.com/priced-1',
         'https://example.com/no-price',
         'https://example.com/priced-2',


### PR DESCRIPTION
See https://github.com/jez500/pricebuddy/pull/168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum priced results limit in SearXng integration settings, allowing the search process to stop after finding a specified number of results with prices.

* **Documentation**
  * Updated testing guidelines to specify PHPUnit-style formatting standards.

* **Tests**
  * Added test coverage for the priced results limit feature and standardized test formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->