### PR TITLE
feat: add meta extraction API endpoint

### DIFF
--- a/app/Casts/StoreScraperStrategySetCast.php
+++ b/app/Casts/StoreScraperStrategySetCast.php
@@ -36,10 +36,6 @@ class StoreScraperStrategySetCast implements CastsAttributes
             return json_encode($value->toArray());
         }
 
-        if (is_array($value)) {
-            return json_encode(StoreScraperStrategySetDto::fromArray($value)->toArray());
-        }
-
-        return json_encode(StoreScraperStrategySetDto::fromArray(null)->toArray());
+        return json_encode(StoreScraperStrategySetDto::fromArray($value)->toArray());
     }
 }

--- a/app/Casts/StoreScraperStrategySetCast.php
+++ b/app/Casts/StoreScraperStrategySetCast.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Casts;
+
+use App\Dto\StoreScraperStrategySetDto;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Casts the stores.scrape_strategy JSON column to/from a StoreScraperStrategySetDto.
+ *
+ * @implements CastsAttributes<StoreScraperStrategySetDto, StoreScraperStrategySetDto|array<string, mixed>>
+ */
+class StoreScraperStrategySetCast implements CastsAttributes
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function get(Model $model, string $key, mixed $value, array $attributes): StoreScraperStrategySetDto
+    {
+        $decoded = is_string($value) ? json_decode($value, true) : $value;
+
+        return StoreScraperStrategySetDto::fromArray(is_array($decoded) ? $decoded : null);
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        if ($value instanceof StoreScraperStrategySetDto) {
+            return json_encode($value->toArray());
+        }
+
+        if (is_array($value)) {
+            return json_encode(StoreScraperStrategySetDto::fromArray($value)->toArray());
+        }
+
+        return json_encode(StoreScraperStrategySetDto::fromArray(null)->toArray());
+    }
+}

--- a/app/Dto/AvailabilityMatchDto.php
+++ b/app/Dto/AvailabilityMatchDto.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Dto;
+
+use App\Enums\AvailabilityMatchType;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * One per-status availability match rule (e.g. out_of_stock => "Sold out").
+ *
+ * @implements Arrayable<string, string>
+ */
+class AvailabilityMatchDto implements Arrayable, JsonSerializable
+{
+    public function __construct(
+        public AvailabilityMatchType $type,
+        public string $value,
+    ) {}
+
+    /**
+     * Build from a stored match entry, or null when there is no usable value.
+     *
+     * @param  array<string, mixed>|null  $data
+     */
+    public static function fromArray(?array $data): ?self
+    {
+        $value = $data['value'] ?? null;
+
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return new self(
+            type: AvailabilityMatchType::tryFrom((string) ($data['type'] ?? 'match')) ?? AvailabilityMatchType::Match,
+            value: (string) $value,
+        );
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return ['type' => $this->type->value, 'value' => $this->value];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/app/Dto/AvailabilityStrategyDto.php
+++ b/app/Dto/AvailabilityStrategyDto.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace App\Dto;
+
+use App\Enums\ScraperStrategyType;
+use App\Enums\StockStatus;
+
+/**
+ * Availability scrape strategy: a standard slot plus per-status match rules and a
+ * fallback status.
+ *
+ * @property array<string, AvailabilityMatchDto> $match
+ */
+class AvailabilityStrategyDto extends StandardStrategyDto
+{
+    /**
+     * @param  array<string, AvailabilityMatchDto>  $match  keyed by StockStatus value
+     */
+    public function __construct(
+        ScraperStrategyType $type,
+        ?string $value = null,
+        ?string $prepend = null,
+        ?string $append = null,
+        public array $match = [],
+        public StockStatus $defaultStatus = StockStatus::InStock,
+    ) {
+        parent::__construct($type, $value, $prepend, $append);
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $data
+     */
+    public static function fromArray(?array $data): ?self
+    {
+        $type = ScraperStrategyType::tryFrom((string) ($data['type'] ?? ''));
+
+        if ($type === null) {
+            return null;
+        }
+
+        $rawMatch = is_array($data['match'] ?? null) ? $data['match'] : [];
+        $defaultStatus = StockStatus::tryFrom((string) ($rawMatch['default'] ?? '')) ?? StockStatus::InStock;
+
+        $match = [];
+        foreach ($rawMatch as $statusValue => $entry) {
+            if ($statusValue === 'default' || ! is_array($entry)) {
+                continue;
+            }
+            $rule = AvailabilityMatchDto::fromArray($entry);
+            if ($rule !== null && StockStatus::tryFrom((string) $statusValue) !== null) {
+                $match[(string) $statusValue] = $rule;
+            }
+        }
+
+        return new self(
+            type: $type,
+            value: self::nullableString($data['value'] ?? null),
+            prepend: self::nullableString($data['prepend'] ?? null),
+            append: self::nullableString($data['append'] ?? null),
+            match: $match,
+            defaultStatus: $defaultStatus,
+        );
+    }
+
+    /**
+     * Rebuild the legacy match-config array consumed by StockStatus::matchFromScrapedValue(),
+     * or null when no per-status rules are configured.
+     *
+     * @return array<string, array{type: string, value: string}|string>|null
+     */
+    public function matchConfig(): ?array
+    {
+        if ($this->match === []) {
+            return null;
+        }
+
+        $out = [];
+        foreach ($this->match as $statusValue => $rule) {
+            $out[$statusValue] = $rule->toArray();
+        }
+        $out['default'] = $this->defaultStatus->value;
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $out = parent::toArray();
+
+        $matchConfig = $this->matchConfig();
+        if ($matchConfig !== null) {
+            $out['match'] = $matchConfig;
+        }
+
+        return $out;
+    }
+}

--- a/app/Dto/AvailabilityStrategyDto.php
+++ b/app/Dto/AvailabilityStrategyDto.php
@@ -8,8 +8,6 @@ use App\Enums\StockStatus;
 /**
  * Availability scrape strategy: a standard slot plus per-status match rules and a
  * fallback status.
- *
- * @property array<string, AvailabilityMatchDto> $match
  */
 class AvailabilityStrategyDto extends StandardStrategyDto
 {
@@ -43,9 +41,20 @@ class AvailabilityStrategyDto extends StandardStrategyDto
 
         $match = [];
         foreach ($rawMatch as $statusValue => $entry) {
-            if ($statusValue === 'default' || ! is_array($entry)) {
+            if ($statusValue === 'default') {
                 continue;
             }
+
+            // Normalize legacy plain-string entries (e.g. 'out_of_stock' => 'Sold out')
+            // into the canonical {type, value} shape before building the rule.
+            if (is_string($entry) && $entry !== '') {
+                $entry = ['type' => 'match', 'value' => $entry];
+            }
+
+            if (! is_array($entry)) {
+                continue;
+            }
+
             $rule = AvailabilityMatchDto::fromArray($entry);
             if ($rule !== null && StockStatus::tryFrom((string) $statusValue) !== null) {
                 $match[(string) $statusValue] = $rule;

--- a/app/Dto/ProductResearchUrlDto.php
+++ b/app/Dto/ProductResearchUrlDto.php
@@ -181,7 +181,7 @@ class ProductResearchUrlDto
         $strategy = [];
 
         if ($this->getIsProductPage() === IsProductPageEnum::YesViaStore) {
-            $strategy = $this->getStore()->scrape_strategy;
+            $strategy = $this->getStore()->scrape_strategy->toArray();
         }
 
         if ($this->getIsProductPage() === IsProductPageEnum::YesViaAutoCreate) {

--- a/app/Dto/StandardStrategyDto.php
+++ b/app/Dto/StandardStrategyDto.php
@@ -59,7 +59,7 @@ class StandardStrategyDto implements Arrayable, JsonSerializable
     {
         $out = ['type' => $this->type->value];
 
-        if ($this->value !== null) {
+        if ($this->value !== null && $this->value !== '') {
             $out['value'] = $this->value;
         }
 

--- a/app/Dto/StandardStrategyDto.php
+++ b/app/Dto/StandardStrategyDto.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Dto;
+
+use App\Enums\ScraperStrategyType;
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * One scrape-strategy slot (title, price, image, description) — how to extract a
+ * single field plus optional static prepend/append decoration.
+ *
+ * @implements Arrayable<string, string>
+ */
+class StandardStrategyDto implements Arrayable, JsonSerializable
+{
+    public function __construct(
+        public ScraperStrategyType $type,
+        public ?string $value = null,
+        public ?string $prepend = null,
+        public ?string $append = null,
+    ) {}
+
+    /**
+     * Build from a stored strategy array, or null when the type is missing/invalid
+     * (the field is then treated as unconfigured). Blank strings normalize to null.
+     *
+     * @param  array<string, mixed>|null  $data
+     */
+    public static function fromArray(?array $data): ?self
+    {
+        $type = ScraperStrategyType::tryFrom((string) ($data['type'] ?? ''));
+
+        if ($type === null) {
+            return null;
+        }
+
+        return new self(
+            type: $type,
+            value: self::nullableString($data['value'] ?? null),
+            prepend: self::nullableString($data['prepend'] ?? null),
+            append: self::nullableString($data['append'] ?? null),
+        );
+    }
+
+    protected static function nullableString(mixed $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        $out = ['type' => $this->type->value];
+
+        if ($this->value !== null) {
+            $out['value'] = $this->value;
+        }
+
+        if ($this->prepend !== null && $this->prepend !== '') {
+            $out['prepend'] = $this->prepend;
+        }
+
+        if ($this->append !== null && $this->append !== '') {
+            $out['append'] = $this->append;
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/app/Dto/StoreScraperStrategySetDto.php
+++ b/app/Dto/StoreScraperStrategySetDto.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Dto;
+
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+/**
+ * The full set of scrape strategies stored on a Store's scrape_strategy column.
+ *
+ * @implements Arrayable<string, array<string, mixed>>
+ */
+class StoreScraperStrategySetDto implements Arrayable, JsonSerializable
+{
+    public function __construct(
+        public ?StandardStrategyDto $title = null,
+        public ?StandardStrategyDto $price = null,
+        public ?StandardStrategyDto $image = null,
+        public ?StandardStrategyDto $description = null,
+        public ?AvailabilityStrategyDto $availability = null,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>|null  $data
+     */
+    public static function fromArray(?array $data): self
+    {
+        $data ??= [];
+
+        return new self(
+            title: StandardStrategyDto::fromArray(self::slot($data, 'title')),
+            price: StandardStrategyDto::fromArray(self::slot($data, 'price')),
+            image: StandardStrategyDto::fromArray(self::slot($data, 'image')),
+            description: StandardStrategyDto::fromArray(self::slot($data, 'description')),
+            availability: AvailabilityStrategyDto::fromArray(self::slot($data, 'availability')),
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>|null
+     */
+    protected static function slot(array $data, string $key): ?array
+    {
+        return is_array($data[$key] ?? null) ? $data[$key] : null;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function toArray(): array
+    {
+        $out = [];
+
+        foreach (['title', 'price', 'image', 'description', 'availability'] as $key) {
+            if ($this->{$key} !== null) {
+                $out[$key] = $this->{$key}->toArray();
+            }
+        }
+
+        return $out;
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/app/Enums/AvailabilityMatchType.php
+++ b/app/Enums/AvailabilityMatchType.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Enums;
+
+enum AvailabilityMatchType: string
+{
+    case Match = 'match';
+
+    case Regex = 'regex';
+}

--- a/app/Enums/StockStatus.php
+++ b/app/Enums/StockStatus.php
@@ -2,6 +2,7 @@
 
 namespace App\Enums;
 
+use App\Dto\AvailabilityStrategyDto;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
@@ -191,16 +192,14 @@ enum StockStatus: string implements HasColor, HasIcon, HasLabel
      * Resolve a scraped availability value against a store's availability strategy.
      * Schema.org strategies infer the status directly from the ItemAvailability value
      * (ignoring any match config); other strategies use the per-status match config.
-     *
-     * @param  array<string, mixed>|null  $availabilityStrategy  The scrape_strategy.availability slot.
      */
-    public static function resolveAvailability(?string $value, ?array $availabilityStrategy): self
+    public static function resolveAvailability(?string $value, ?AvailabilityStrategyDto $availabilityStrategy): self
     {
-        if (data_get($availabilityStrategy, 'type') === ScraperStrategyType::SchemaOrg->value) {
+        if ($availabilityStrategy?->type === ScraperStrategyType::SchemaOrg) {
             return self::fromSchemaOrgAvailability($value);
         }
 
-        return self::matchFromScrapedValue($value, data_get($availabilityStrategy, 'match'));
+        return self::matchFromScrapedValue($value, $availabilityStrategy?->matchConfig());
     }
 
     /**

--- a/app/Http/Controllers/Api/MetaExtractionController.php
+++ b/app/Http/Controllers/Api/MetaExtractionController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\MetaExtractionRequest;
+use App\Http\Resources\MetaExtractionResource;
+use App\Services\MetaExtractionService;
+use Dedoc\Scramble\Attributes\Group;
+
+#[Group('MetaExtraction')]
+class MetaExtractionController extends Controller
+{
+    public function __construct(
+        protected MetaExtractionService $metaExtractionService,
+    ) {}
+
+    /**
+     * Extract meta data from a URL
+     */
+    public function __invoke(MetaExtractionRequest $request): MetaExtractionResource
+    {
+        $validated = $request->validated();
+
+        return new MetaExtractionResource($this->metaExtractionService->extract(
+            $validated['url'],
+            $validated['store'] ?? [],
+        ));
+    }
+}

--- a/app/Http/Requests/MetaExtractionRequest.php
+++ b/app/Http/Requests/MetaExtractionRequest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Http\Requests;
+
+use App\Enums\ScraperService;
+use App\Enums\ScraperStrategyType;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class MetaExtractionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'url' => ['required', 'url'],
+            'store' => ['sometimes', 'array'],
+            'store.name' => ['sometimes', 'string', 'max:255'],
+            'store.domains' => ['sometimes', 'array'],
+            'store.domains.*.domain' => ['required_with:store.domains', 'string'],
+            'store.settings' => ['sometimes', 'array'],
+            'store.settings.scraper_service' => ['sometimes', 'in:'.implode(',', ScraperService::values())],
+            'store.settings.scraper_service_settings' => ['nullable', 'string'],
+            'store.settings.locale_settings.locale' => ['sometimes', 'string'],
+            'store.settings.locale_settings.currency' => ['sometimes', 'string'],
+            'store.settings.cookies' => ['nullable', 'string'],
+            'store.scrape_strategy' => ['sometimes', 'array'],
+            'store.scrape_strategy.title' => ['sometimes', 'array'],
+            'store.scrape_strategy.title.type' => ['sometimes', 'in:'.implode(',', ScraperStrategyType::values())],
+            'store.scrape_strategy.title.value' => $this->scrapeStrategyValueRules('title'),
+            'store.scrape_strategy.title.prepend' => ['nullable', 'string'],
+            'store.scrape_strategy.title.append' => ['nullable', 'string'],
+            'store.scrape_strategy.price' => ['sometimes', 'array'],
+            'store.scrape_strategy.price.type' => ['sometimes', 'in:'.implode(',', ScraperStrategyType::values())],
+            'store.scrape_strategy.price.value' => $this->scrapeStrategyValueRules('price'),
+            'store.scrape_strategy.price.prepend' => ['nullable', 'string'],
+            'store.scrape_strategy.price.append' => ['nullable', 'string'],
+            'store.scrape_strategy.image' => ['sometimes', 'array'],
+            'store.scrape_strategy.image.type' => ['sometimes', 'in:'.implode(',', ScraperStrategyType::values())],
+            'store.scrape_strategy.image.value' => $this->scrapeStrategyValueRules('image'),
+            'store.scrape_strategy.image.prepend' => ['nullable', 'string'],
+            'store.scrape_strategy.image.append' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * @return array<int, mixed>
+     */
+    protected function scrapeStrategyValueRules(string $field): array
+    {
+        return [
+            Rule::requiredIf(function () use ($field): bool {
+                $type = data_get($this->input(), "store.scrape_strategy.{$field}.type");
+
+                return filled($type) && $type !== ScraperStrategyType::SchemaOrg->value;
+            }),
+            function (string $attribute, mixed $value, Closure $fail) use ($field): void {
+                $type = data_get($this->input(), "store.scrape_strategy.{$field}.type");
+
+                if ($type === ScraperStrategyType::SchemaOrg->value) {
+                    if (! is_null($value)) {
+                        $fail("The {$attribute} field must be null when using schema_org.");
+                    }
+
+                    return;
+                }
+
+                if (! is_string($value) || trim($value) === '') {
+                    $fail("The {$attribute} field must be a non-empty string.");
+                }
+            },
+        ];
+    }
+}

--- a/app/Http/Requests/MetaExtractionRequest.php
+++ b/app/Http/Requests/MetaExtractionRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests;
 
 use App\Enums\ScraperService;
 use App\Enums\ScraperStrategyType;
+use App\Rules\PublicHttpUrl;
 use Closure;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
@@ -18,7 +19,7 @@ class MetaExtractionRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'url' => ['required', 'url'],
+            'url' => ['required', 'string', new PublicHttpUrl],
             'store' => ['sometimes', 'array'],
             'store.name' => ['sometimes', 'string', 'max:255'],
             'store.domains' => ['sometimes', 'array'],

--- a/app/Http/Resources/MetaExtractionResource.php
+++ b/app/Http/Resources/MetaExtractionResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property array $resource
+ */
+class MetaExtractionResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        $store = data_get($this->resource, 'store');
+
+        return [
+            'title' => data_get($this->resource, 'title'),
+            'price' => data_get($this->resource, 'price'),
+            'image' => data_get($this->resource, 'image'),
+            'description' => data_get($this->resource, 'description'),
+            'availability' => data_get($this->resource, 'availability'),
+            /** @var array<string, StoreResource> */
+            'store' => $store ? new StoreResource($store) : (object) [],
+        ];
+    }
+}

--- a/app/Http/Resources/StoreResource.php
+++ b/app/Http/Resources/StoreResource.php
@@ -24,6 +24,8 @@ class StoreResource extends JsonResource
             'slug' => $this->resource->slug,
             'initials' => $this->resource->initials,
             'domains' => $this->resource->domains,
+            'scrape_settings' => $this->resource->scrape_strategy,
+            'settings' => $this->resource->settings,
         ];
     }
 }

--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -2,6 +2,8 @@
 
 namespace App\Models;
 
+use App\Casts\StoreScraperStrategySetCast;
+use App\Dto\StoreScraperStrategySetDto;
 use App\Enums\ScraperService;
 use App\Services\Helpers\CurrencyHelper;
 use Database\Factories\StoreFactory;
@@ -25,7 +27,7 @@ use Spatie\Sluggable\SlugOptions;
  * @property string $initials
  * @property array $domains
  * @property HtmlString $domains_html
- * @property array $scrape_strategy
+ * @property StoreScraperStrategySetDto $scrape_strategy
  * @property array $settings
  * @property string $scraper_service
  * @property array $scraper_options
@@ -61,7 +63,7 @@ class Store extends Model
     {
         return [
             'domains' => 'array',
-            'scrape_strategy' => 'array',
+            'scrape_strategy' => StoreScraperStrategySetCast::class,
             'settings' => 'array',
         ];
     }

--- a/app/Rules/PublicHttpUrl.php
+++ b/app/Rules/PublicHttpUrl.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\Rules;
+
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Validates that a URL is a publicly reachable http/https target and not an
+ * internal, loopback, link-local or otherwise reserved host. Guards the
+ * server-side scraper against SSRF (e.g. cloud metadata at 169.254.169.254,
+ * internal services on RFC1918 ranges, or hostnames that resolve to them).
+ */
+class PublicHttpUrl implements ValidationRule
+{
+    /**
+     * IPv4 ranges that must never be reached server-side.
+     *
+     * @var array<int, string>
+     */
+    protected array $blockedIpv4 = [
+        '0.0.0.0/8',        // "this" network
+        '10.0.0.0/8',       // RFC1918 private
+        '100.64.0.0/10',    // RFC6598 carrier-grade NAT
+        '127.0.0.0/8',      // loopback
+        '169.254.0.0/16',   // RFC3927 link-local (incl. cloud metadata)
+        '172.16.0.0/12',    // RFC1918 private
+        '192.0.0.0/24',     // IETF protocol assignments
+        '192.0.2.0/24',     // TEST-NET-1
+        '192.88.99.0/24',   // 6to4 relay anycast
+        '192.168.0.0/16',   // RFC1918 private
+        '198.18.0.0/15',    // benchmarking
+        '198.51.100.0/24',  // TEST-NET-2
+        '203.0.113.0/24',   // TEST-NET-3
+        '224.0.0.0/4',      // multicast
+        '240.0.0.0/4',      // reserved
+        '255.255.255.255/32', // broadcast
+    ];
+
+    /**
+     * IPv6 ranges that must never be reached server-side.
+     *
+     * @var array<int, string>
+     */
+    protected array $blockedIpv6 = [
+        '::1/128',      // loopback
+        '::/128',       // unspecified
+        '64:ff9b::/96', // NAT64
+        '100::/64',     // discard-only
+        '2001:db8::/32', // documentation
+        'fc00::/7',     // unique local address
+        'fe80::/10',    // link-local
+        'ff00::/8',     // multicast
+    ];
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_string($value) || trim($value) === '') {
+            $fail('The :attribute must be a valid URL.');
+
+            return;
+        }
+
+        $parts = parse_url($value);
+
+        if ($parts === false || ! isset($parts['scheme'], $parts['host'])) {
+            $fail('The :attribute must be a valid URL.');
+
+            return;
+        }
+
+        if (! in_array(strtolower($parts['scheme']), ['http', 'https'], true)) {
+            $fail('The :attribute must use the http or https scheme.');
+
+            return;
+        }
+
+        $host = $this->normaliseHost($parts['host']);
+
+        if ($host === '' || $this->isBlockedHostname($host)) {
+            $fail('The :attribute must not point to an internal or reserved host.');
+
+            return;
+        }
+
+        $ips = filter_var($host, FILTER_VALIDATE_IP) ? [$host] : $this->resolveHostIps($host);
+
+        if ($ips === []) {
+            $fail('The :attribute host could not be resolved.');
+
+            return;
+        }
+
+        foreach ($ips as $ip) {
+            if (! $this->isPublicIp($ip)) {
+                $fail('The :attribute must not point to an internal or reserved host.');
+
+                return;
+            }
+        }
+    }
+
+    /**
+     * Lowercase, strip IPv6 brackets, and convert IDN/punycode to ASCII so
+     * unicode variants of blocked hosts cannot bypass the checks.
+     */
+    protected function normaliseHost(string $host): string
+    {
+        $host = strtolower(trim($host, '[]'));
+
+        if ($host !== '' && function_exists('idn_to_ascii')) {
+            $ascii = idn_to_ascii($host);
+
+            if (is_string($ascii) && $ascii !== '') {
+                $host = $ascii;
+            }
+        }
+
+        return $host;
+    }
+
+    protected function isBlockedHostname(string $host): bool
+    {
+        return $host === 'localhost' || str_ends_with($host, '.localhost');
+    }
+
+    /**
+     * Resolve a hostname to its A and AAAA records.
+     *
+     * @return array<int, string>
+     */
+    protected function resolveHostIps(string $host): array
+    {
+        $ips = [];
+
+        foreach (gethostbynamel($host) ?: [] as $ip) {
+            $ips[] = $ip;
+        }
+
+        foreach (@dns_get_record($host, DNS_AAAA) ?: [] as $record) {
+            if (! empty($record['ipv6'])) {
+                $ips[] = $record['ipv6'];
+            }
+        }
+
+        return array_values(array_unique($ips));
+    }
+
+    protected function isPublicIp(string $ip): bool
+    {
+        $ip = $this->unwrapMappedIpv4($ip);
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+            foreach ($this->blockedIpv4 as $cidr) {
+                if ($this->ipInCidr($ip, $cidr)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+            foreach ($this->blockedIpv6 as $cidr) {
+                if ($this->ipInCidr($ip, $cidr)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Convert an IPv4-mapped IPv6 address (::ffff:1.2.3.4) to its IPv4 form so it
+     * is checked against the IPv4 block list.
+     */
+    protected function unwrapMappedIpv4(string $ip): string
+    {
+        if (stripos($ip, '::ffff:') === 0) {
+            $tail = substr($ip, 7);
+
+            if (filter_var($tail, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+                return $tail;
+            }
+
+            $packed = @inet_pton($ip);
+
+            if ($packed !== false && strlen($packed) === 16) {
+                return inet_ntop(substr($packed, 12));
+            }
+        }
+
+        return $ip;
+    }
+
+    protected function ipInCidr(string $ip, string $cidr): bool
+    {
+        [$subnet, $bits] = explode('/', $cidr);
+        $bits = (int) $bits;
+
+        $ipPacked = @inet_pton($ip);
+        $subnetPacked = @inet_pton($subnet);
+
+        if ($ipPacked === false || $subnetPacked === false || strlen($ipPacked) !== strlen($subnetPacked)) {
+            return false;
+        }
+
+        $bytes = intdiv($bits, 8);
+        $remainder = $bits % 8;
+
+        if ($bytes > 0 && strncmp($ipPacked, $subnetPacked, $bytes) !== 0) {
+            return false;
+        }
+
+        if ($remainder === 0) {
+            return true;
+        }
+
+        $mask = chr(0xFF << (8 - $remainder) & 0xFF);
+
+        return (ord($ipPacked[$bytes]) & ord($mask)) === (ord($subnetPacked[$bytes]) & ord($mask));
+    }
+}

--- a/app/Services/Ai/HealingContext.php
+++ b/app/Services/Ai/HealingContext.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Ai;
 
+use App\Dto\StandardStrategyDto;
 use App\Enums\ScraperService;
 use App\Models\Store;
 use App\Services\StrategyExtractor;
@@ -123,7 +124,8 @@ class HealingContext
         }
 
         try {
-            $extracted = StrategyExtractor::extract($this->scraper(), ['type' => $type, 'value' => $value], 'price');
+            $dto = StandardStrategyDto::fromArray(['type' => $type, 'value' => $value]);
+            $extracted = $dto ? StrategyExtractor::extract($this->scraper(), $dto, 'price') : null;
         } catch (Throwable $e) {
             return ['matched' => false, 'value' => null, 'error' => $e->getMessage()];
         }

--- a/app/Services/AiConfigHealer.php
+++ b/app/Services/AiConfigHealer.php
@@ -442,7 +442,7 @@ class AiConfigHealer
      */
     protected function applyValidatedSlots(Store $store, array $validated): void
     {
-        $strategy = $store->scrape_strategy ?? [];
+        $strategy = $store->scrape_strategy->toArray();
 
         foreach ($validated as $field => $slot) {
             $strategy[$field] = $slot;

--- a/app/Services/AiConfigHealer.php
+++ b/app/Services/AiConfigHealer.php
@@ -4,6 +4,7 @@ namespace App\Services;
 
 use App\Actions\CreateStoreAction;
 use App\Dto\AiProviderConfigDto;
+use App\Dto\StoreScraperStrategySetDto;
 use App\Enums\AiFeature;
 use App\Enums\ScraperService;
 use App\Enums\StockStatus;
@@ -448,7 +449,7 @@ class AiConfigHealer
             $strategy[$field] = $slot;
         }
 
-        $store->scrape_strategy = $strategy;
+        $store->scrape_strategy = StoreScraperStrategySetDto::fromArray($strategy);
     }
 
     /**

--- a/app/Services/AiConfigHealer.php
+++ b/app/Services/AiConfigHealer.php
@@ -313,6 +313,19 @@ class AiConfigHealer
     }
 
     /**
+     * Apply a previewForUrl() config to a store IN MEMORY (no persistence): merges the
+     * validated field slots and switches to the browser scraper when the config required
+     * it. For callers (e.g. the meta-extraction API) that want the healed config on the
+     * returned store without creating or saving anything.
+     *
+     * @param  array{fields: array<string, array<string, mixed>>, usedBrowser: bool}  $config
+     */
+    public function applyPreviewToStore(Store $store, array $config): void
+    {
+        $this->applyConfigToStore($store, $config);
+    }
+
+    /**
      * Apply a resolved config's fields to a store (in memory) and switch it to the
      * browser scraper when the resolution required browser rendering. Caller persists.
      *

--- a/app/Services/AiConfigHealer.php
+++ b/app/Services/AiConfigHealer.php
@@ -318,7 +318,7 @@ class AiConfigHealer
      * it. For callers (e.g. the meta-extraction API) that want the healed config on the
      * returned store without creating or saving anything.
      *
-     * @param  array{fields: array<string, array<string, mixed>>, usedBrowser: bool}  $config
+     * @param  array{fields: array<string, array<string, mixed>>, extracted: array<string, mixed>, usedBrowser: bool}  $config
      */
     public function applyPreviewToStore(Store $store, array $config): void
     {

--- a/app/Services/AutoCreateStore.php
+++ b/app/Services/AutoCreateStore.php
@@ -233,7 +233,8 @@ class AutoCreateStore
 
     protected function attemptSchemaOrg(string $field, ?Closure $validateValue = null): ?array
     {
-        $extracted = SchemaOrgService::parseSchemaOrg($this->scraperService->getSchemaOrg(), $field);
+        $extracted = SchemaOrgService::parseSchemaOrg($this->scraperService->getSchemaOrg(), $field)
+            ?? SchemaOrgService::parseMicrodata($this->html, $field);
 
         $value = is_null($validateValue)
             ? $extracted

--- a/app/Services/MetaExtractionService.php
+++ b/app/Services/MetaExtractionService.php
@@ -61,15 +61,35 @@ class MetaExtractionService
         $autoCreateStore = AutoCreateStore::new($url, timeout: $this->timeout)
             ->setLogErrors(false);
 
-        $result = $autoCreateStore->strategyParse();
-        $price = data_get($result, 'price.data');
+        $detected = $autoCreateStore->detect();
+
+        // No viable (title+price) strategy detected: return whatever partial
+        // title/price/image was found, without a store to hand back.
+        if ($detected === null) {
+            $result = $autoCreateStore->strategyParse();
+            $price = data_get($result, 'price.data');
+
+            return [
+                'title' => data_get($result, 'title.data'),
+                'price' => $price === null || $price === ''
+                    ? null
+                    : CurrencyHelper::toFloat($price),
+                'image' => data_get($result, 'image.data'),
+            ];
+        }
+
+        $price = data_get($detected, 'extracted.price');
 
         return [
-            'title' => data_get($result, 'title.data'),
+            'title' => data_get($detected, 'extracted.title'),
             'price' => $price === null || $price === ''
                 ? null
                 : CurrencyHelper::toFloat($price),
-            'image' => data_get($result, 'image.data'),
+            'image' => data_get($detected, 'extracted.image'),
+            'availability' => data_get($detected, 'extracted.availability'),
+            // Return the detected (unsaved) store so a successful auto-create
+            // extraction always carries the strategy it built.
+            'store' => new Store(AutoCreateStore::buildAttributes($url, $detected['fields'])),
         ];
     }
 

--- a/app/Services/MetaExtractionService.php
+++ b/app/Services/MetaExtractionService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Enums\ScraperService;
 use App\Enums\StockStatus;
 use App\Models\Store;
 use App\Services\Helpers\CurrencyHelper;
@@ -116,9 +117,31 @@ class MetaExtractionService
 
         $detected = $autoCreateStore->detect();
 
-        // No viable (title+price) strategy detected: return whatever partial
-        // title/price/image was found, without a store to hand back.
+        // No viable (title+price) strategy detected deterministically: try preview-only
+        // AI healing, and fall back to whatever partial data was found (no store).
         if ($detected === null) {
+            $config = $this->healPreview($url, null, $autoCreateStore->getHtml());
+
+            if ($config !== null) {
+                $attributes = AutoCreateStore::buildAttributes($url, $config['fields']);
+
+                if ($config['usedBrowser']) {
+                    data_set($attributes, 'settings.scraper_service', ScraperService::Api->value);
+                }
+
+                $price = data_get($config, 'extracted.price');
+
+                return [
+                    'title' => data_get($config, 'extracted.title'),
+                    'price' => $price === null || $price === ''
+                        ? null
+                        : CurrencyHelper::toFloat($price),
+                    'image' => data_get($config, 'extracted.image'),
+                    'availability' => data_get($config, 'extracted.availability'),
+                    'store' => new Store($attributes),
+                ];
+            }
+
             $result = $autoCreateStore->strategyParse();
             $price = data_get($result, 'price.data');
 

--- a/app/Services/MetaExtractionService.php
+++ b/app/Services/MetaExtractionService.php
@@ -93,7 +93,7 @@ class MetaExtractionService
                 ['domain' => $host],
             ]),
             'scrape_strategy' => array_replace_recursive(
-                $store->scrape_strategy ?? [],
+                $store?->scrape_strategy?->toArray() ?? [],
                 data_get($storeOverride, 'scrape_strategy', [])
             ),
             'settings' => array_replace_recursive(

--- a/app/Services/MetaExtractionService.php
+++ b/app/Services/MetaExtractionService.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Store;
+use App\Services\Helpers\CurrencyHelper;
+use Illuminate\Support\Uri;
+
+class MetaExtractionService
+{
+    public function __construct(
+        protected int $timeout = 10,
+    ) {}
+
+    public static function new(int $timeout = 10): self
+    {
+        return resolve(static::class, [
+            'timeout' => $timeout,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $storeOverride
+     * @return array<string, mixed>
+     */
+    public function extract(string $url, array $storeOverride = []): array
+    {
+        $store = $this->resolveStore($url, $storeOverride);
+
+        if ($store) {
+            return $this->extractWithStore($url, $store);
+        }
+
+        return $this->extractWithAutoCreate($url);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function extractWithStore(string $url, Store $store): array
+    {
+        $result = ScrapeUrl::new($url)
+            ->setMaxAttempts(1)
+            ->setConnectTimeout($this->timeout)
+            ->setRequestTimeout($this->timeout)
+            ->setLogErrors(false)
+            ->setSendUiNotifications(false)
+            ->scrape([
+                'store' => $store,
+                'use_cache' => false,
+            ]);
+
+        return $this->normalizeResult($result);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function extractWithAutoCreate(string $url): array
+    {
+        $autoCreateStore = AutoCreateStore::new($url, timeout: $this->timeout)
+            ->setLogErrors(false);
+
+        $result = $autoCreateStore->strategyParse();
+        $price = data_get($result, 'price.data');
+
+        return [
+            'title' => data_get($result, 'title.data'),
+            'price' => $price === null || $price === ''
+                ? null
+                : CurrencyHelper::toFloat($price),
+            'image' => data_get($result, 'image.data'),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $storeOverride
+     */
+    protected function resolveStore(string $url, array $storeOverride = []): ?Store
+    {
+        $host = Uri::of($url)->host();
+        $store = Store::query()->domainFilter($host)->oldest()->first();
+
+        if (empty($storeOverride)) {
+            return $store;
+        }
+
+        $overrideCookies = data_get($storeOverride, 'settings.cookies', data_get($storeOverride, 'cookies', $store?->cookies));
+
+        $merged = [
+            'name' => data_get($storeOverride, 'name', $store->name ?? ucfirst($host)),
+            'domains' => data_get($storeOverride, 'domains', $store->domains ?? [
+                ['domain' => $host],
+            ]),
+            'scrape_strategy' => array_replace_recursive(
+                $store->scrape_strategy ?? [],
+                data_get($storeOverride, 'scrape_strategy', [])
+            ),
+            'settings' => array_replace_recursive(
+                $store->settings ?? [],
+                data_get($storeOverride, 'settings', [])
+            ),
+        ];
+
+        if (! is_null($overrideCookies)) {
+            $merged['cookies'] = $overrideCookies;
+        }
+
+        return new Store($merged);
+    }
+
+    /**
+     * @param  array<string, mixed>  $result
+     * @return array<string, mixed>
+     */
+    protected function normalizeResult(array $result): array
+    {
+        $price = data_get($result, 'price');
+
+        return [
+            'title' => data_get($result, 'title'),
+            'price' => $price === null || $price === ''
+                ? null
+                : CurrencyHelper::toFloat($price),
+            'image' => data_get($result, 'image'),
+            'description' => data_get($result, 'description'),
+            'availability' => data_get($result, 'availability'),
+            'store' => data_get($result, 'store'),
+        ];
+    }
+}

--- a/app/Services/MetaExtractionService.php
+++ b/app/Services/MetaExtractionService.php
@@ -2,9 +2,11 @@
 
 namespace App\Services;
 
+use App\Enums\StockStatus;
 use App\Models\Store;
 use App\Services\Helpers\CurrencyHelper;
 use Illuminate\Support\Uri;
+use Throwable;
 
 class MetaExtractionService
 {
@@ -50,7 +52,58 @@ class MetaExtractionService
                 'use_cache' => false,
             ]);
 
+        if ($this->shouldHeal($store, $result)) {
+            $config = $this->healPreview($url, $store, data_get($result, 'body'));
+
+            if ($config !== null) {
+                AiConfigHealer::new()->applyPreviewToStore($store, $config);
+
+                foreach ($config['extracted'] as $field => $value) {
+                    data_set($result, $field, $value);
+                }
+            }
+        }
+
         return $this->normalizeResult($result);
+    }
+
+    /**
+     * Whether a failed-to-find-price scrape should attempt AI healing. Mirrors the UI
+     * add-URL gate: only when the store hasn't opted out, no price was found, and the
+     * item is not detected as unavailable. The global Healing feature flag is enforced
+     * separately by previewForUrl().
+     *
+     * @param  array<string, mixed>  $rawScrapeResult
+     */
+    private function shouldHeal(Store $store, array $rawScrapeResult): bool
+    {
+        if ($store->ai_self_healing_disabled) {
+            return false;
+        }
+
+        if (! empty(data_get($rawScrapeResult, 'price'))) {
+            return false;
+        }
+
+        return ! StockStatus::resolveAvailability(
+            data_get($rawScrapeResult, 'availability'),
+            $store->scrape_strategy->availability,
+        )->isUnavailable();
+    }
+
+    /**
+     * Run preview-only AI healing for the URL, swallowing any error so a healing failure
+     * never turns a normal extraction into a 500.
+     *
+     * @return array{fields: array<string, array<string, mixed>>, extracted: array<string, mixed>, usedBrowser: bool}|null
+     */
+    private function healPreview(string $url, ?Store $store, ?string $html): ?array
+    {
+        try {
+            return AiConfigHealer::new()->previewForUrl($url, $store, $html);
+        } catch (Throwable $e) {
+            return null;
+        }
     }
 
     /**

--- a/app/Services/MetaExtractionService.php
+++ b/app/Services/MetaExtractionService.php
@@ -82,7 +82,7 @@ class MetaExtractionService
             return false;
         }
 
-        if (! empty(data_get($rawScrapeResult, 'price'))) {
+        if (filled(data_get($rawScrapeResult, 'price'))) {
             return false;
         }
 

--- a/app/Services/ProductSourceSearchService.php
+++ b/app/Services/ProductSourceSearchService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Dto\StandardStrategyDto;
 use App\Models\ProductSource;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
@@ -113,8 +114,14 @@ class ProductSourceSearchService
      */
     protected function extractValue(WebScraperInterface $scraper, array $slot, string $field): ?string
     {
+        $dto = StandardStrategyDto::fromArray($slot);
+
+        if ($dto === null) {
+            return null;
+        }
+
         try {
-            return StrategyExtractor::extract($scraper, $slot, $field);
+            return StrategyExtractor::extract($scraper, $dto, $field);
         } catch (DomSelectorException $e) {
             $this->errorLog('Error extracting field from search result item', [
                 'field' => $field,

--- a/app/Services/SchemaOrgService.php
+++ b/app/Services/SchemaOrgService.php
@@ -110,6 +110,10 @@ class SchemaOrgService
 
         $tag = strtolower($node->nodeName());
 
+        if ($tag === 'data' && filled($value = $node->attr('value'))) {
+            return trim($value);
+        }
+
         if (in_array($tag, ['img', 'source', 'iframe', 'embed', 'video', 'audio', 'track'], true)
             && filled($src = $node->attr('src'))) {
             return trim($src);

--- a/app/Services/SchemaOrgService.php
+++ b/app/Services/SchemaOrgService.php
@@ -32,7 +32,7 @@ class SchemaOrgService
             return null;
         }
 
-        return match ($field) {
+        $value = match ($field) {
             // Get title from name.
             'title' => data_get($schema, 'name'),
             // Full description.
@@ -41,10 +41,8 @@ class SchemaOrgService
             'price' => data_get($schema, 'offers.lowPrice', data_get($schema, 'offers.price', data_get($schema, 'offers.0.price', data_get($schema, 'offers.priceSpecification.price')))),
             // Currency.
             'price_currency' => data_get($schema, 'offers.priceCurrency', data_get($schema, 'offers.0.priceCurrency', data_get($schema, 'offers.priceSpecification.priceCurrency', 'USD'))),
-            // Image should be a string, sometimes array of strings.
-            'image' => is_string(data_get($schema, 'image'))
-                ? data_get($schema, 'image')
-                : (is_array(data_get($schema, 'image')) ? data_get($schema, 'image.0') : null),
+            // Image: a string, an array of strings, an ImageObject ({url: ...}), or an array of those.
+            'image' => self::firstImageString(data_get($schema, 'image')),
             // Availability should be a string, sometimes array of strings.
             'availability' => is_string(data_get($schema, 'offers.availability', data_get($schema, 'offers.0.availability')))
                 ? data_get($schema, 'offers.availability', data_get($schema, 'offers.0.availability'))
@@ -53,6 +51,46 @@ class SchemaOrgService
                     : null),
             default => null
         };
+
+        // Schema.org fields are occasionally nested arrays/objects; coerce scalars to
+        // string and anything non-stringable to null so the ?string contract always holds.
+        if (is_array($value)) {
+            return null;
+        }
+
+        return $value === null ? null : (string) $value;
+    }
+
+    /**
+     * Resolve the first usable image URL string from a schema.org image value, which may be
+     * a string, an array of strings, an ImageObject (`{"url": ...}`), or an array of those.
+     */
+    private static function firstImageString(mixed $image): ?string
+    {
+        if (is_string($image)) {
+            return $image;
+        }
+
+        if (! is_array($image)) {
+            return null;
+        }
+
+        // Single ImageObject: {"@type": "ImageObject", "url": "..."}.
+        if (is_string($url = data_get($image, 'url'))) {
+            return $url;
+        }
+
+        foreach ($image as $item) {
+            if (is_string($item)) {
+                return $item;
+            }
+
+            if (is_array($item) && is_string($url = data_get($item, 'url'))) {
+                return $url;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/app/Services/SchemaOrgService.php
+++ b/app/Services/SchemaOrgService.php
@@ -3,6 +3,8 @@
 namespace App\Services;
 
 use Illuminate\Support\Collection;
+use Symfony\Component\DomCrawler\Crawler;
+use Throwable;
 
 class SchemaOrgService
 {
@@ -51,5 +53,72 @@ class SchemaOrgService
                     : null),
             default => null
         };
+    }
+
+    /**
+     * Extract a product field from HTML microdata (itemscope/itemprop) as a fallback to
+     * JSON-LD. Anchored to a schema.org/Product itemscope. Returns null when the HTML is
+     * blank, has no Product microdata, lacks the field, or any Crawler error occurs.
+     */
+    public static function parseMicrodata(?string $html, string $field): ?string
+    {
+        if (blank($html)) {
+            return null;
+        }
+
+        $itemprop = match ($field) {
+            'title' => 'name',
+            'description' => 'description',
+            'price' => 'price',
+            'price_currency' => 'priceCurrency',
+            'image' => 'image',
+            'availability' => 'availability',
+            default => null,
+        };
+
+        if ($itemprop === null) {
+            return null;
+        }
+
+        try {
+            $product = (new Crawler($html))
+                ->filter('[itemscope][itemtype*="schema.org/Product"]')
+                ->first();
+
+            if (! $product->count()) {
+                return null;
+            }
+
+            $node = $product->filter('[itemprop="'.$itemprop.'"]')->first();
+
+            return $node->count() ? self::microdataValue($node) : null;
+        } catch (Throwable $e) {
+            return null;
+        }
+    }
+
+    /**
+     * Resolve a microdata property node's value: the `content` attribute, else a media
+     * element's `src`, else a link element's `href`, else the trimmed text content.
+     */
+    private static function microdataValue(Crawler $node): ?string
+    {
+        $content = $node->attr('content');
+        if ($content !== null && trim($content) !== '') {
+            return trim($content);
+        }
+
+        $tag = strtolower($node->nodeName());
+
+        if (in_array($tag, ['img', 'source', 'iframe', 'embed', 'video', 'audio', 'track'], true)
+            && filled($src = $node->attr('src'))) {
+            return trim($src);
+        }
+
+        if (in_array($tag, ['a', 'link', 'area'], true) && filled($href = $node->attr('href'))) {
+            return trim($href);
+        }
+
+        return filled($text = trim($node->text(''))) ? $text : null;
     }
 }

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Dto\StandardStrategyDto;
 use App\Enums\ScraperService;
 use App\Enums\ScraperStrategyType;
 use App\Enums\StockStatus;
@@ -196,14 +197,13 @@ class ScrapeUrl
                 return $output;
             }
 
-            $strategy = data_get($store, 'scrape_strategy', []);
+            $strategy = $store->scrape_strategy;
 
             foreach ($this->keys as $key) {
-                if (empty($strategy[$key]) || ! is_array($strategy[$key])) {
-                    $output[$key] = null;
-                } else {
-                    $output[$key] = $this->scrapeOption($page, $strategy[$key], $key);
-                }
+                $slot = $strategy->{$key} ?? null;
+                $output[$key] = $slot instanceof StandardStrategyDto
+                    ? $this->scrapeOption($page, $slot, $key)
+                    : null;
             }
 
             $output['body'] = $page->getBody();
@@ -224,7 +224,7 @@ class ScrapeUrl
         return Store::query()->domainFilter($host)->oldest()->first();
     }
 
-    protected function scrapeOption(WebScraperInterface $scraper, array $options, string $field): ?string
+    protected function scrapeOption(WebScraperInterface $scraper, StandardStrategyDto $options, string $field): ?string
     {
         try {
             return StrategyExtractor::extract($scraper, $options, $field);

--- a/app/Services/StrategyExtractor.php
+++ b/app/Services/StrategyExtractor.php
@@ -21,7 +21,8 @@ class StrategyExtractor
         $type = $slot->type;
 
         if ($type === ScraperStrategyType::SchemaOrg) {
-            return SchemaOrgService::parseSchemaOrg($scraper->getSchemaOrg(), $field);
+            return SchemaOrgService::parseSchemaOrg($scraper->getSchemaOrg(), $field)
+                ?? SchemaOrgService::parseMicrodata($scraper->getBody(), $field);
         }
 
         $value = $slot->value;

--- a/app/Services/StrategyExtractor.php
+++ b/app/Services/StrategyExtractor.php
@@ -2,6 +2,7 @@
 
 namespace App\Services;
 
+use App\Dto\StandardStrategyDto;
 use App\Enums\ScraperStrategyType;
 use Jez500\WebScraperForLaravel\WebScraperInterface;
 
@@ -14,31 +15,26 @@ class StrategyExtractor
      *
      * May throw Jez500\WebScraperForLaravel\Exceptions\DomSelectorException on an
      * invalid selector/xpath; callers decide whether to swallow or surface it.
-     *
-     * @param  array<string, mixed>  $slot
      */
-    public static function extract(WebScraperInterface $scraper, array $slot, string $field): ?string
+    public static function extract(WebScraperInterface $scraper, StandardStrategyDto $slot, string $field): ?string
     {
-        $type = data_get($slot, 'type');
-        $value = data_get($slot, 'value');
+        $type = $slot->type;
 
-        if (! is_string($type) || $type === '') {
-            return null;
-        }
-
-        if (! is_string($value) && $type !== ScraperStrategyType::SchemaOrg->value) {
-            return null;
-        }
-
-        if ($type === ScraperStrategyType::SchemaOrg->value) {
+        if ($type === ScraperStrategyType::SchemaOrg) {
             return SchemaOrgService::parseSchemaOrg($scraper->getSchemaOrg(), $field);
         }
 
-        $method = ScrapeUrl::getMethodFromType($type);
+        $value = $slot->value;
+
+        if ($value === null) {
+            return null;
+        }
+
+        $method = ScrapeUrl::getMethodFromType($type->value);
 
         $args = match ($type) {
-            ScraperStrategyType::Selector->value => ScrapeUrl::parseSelector($value),
-            ScraperStrategyType::Regex->value => [ScrapeUrl::ensureRegexDelimiters($value)],
+            ScraperStrategyType::Selector => ScrapeUrl::parseSelector($value),
+            ScraperStrategyType::Regex => [ScrapeUrl::ensureRegexDelimiters($value)],
             default => [$value],
         };
 
@@ -49,9 +45,9 @@ class StrategyExtractor
         }
 
         return implode('', [
-            data_get($slot, 'prepend', ''),
+            $slot->prepend ?? '',
             $extracted,
-            data_get($slot, 'append', ''),
+            $slot->append ?? '',
         ]);
     }
 }

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -20,3 +20,44 @@ The API documentation is generated using the application code and can be viewed 
 
 Via the docs you can test out the API with your API token, see request and response formats and even
 export the openapi json spec.
+
+## Meta Extraction
+
+`POST /api/meta-extraction`
+
+Use this endpoint to extract `title`, `price`, and `image` from a product URL without persisting anything.
+It automatically uses a matching store configuration based on the URL domain and can also accept a
+`store` override payload when you want to test a custom scrape strategy.
+
+Example request:
+
+```json
+{
+  "url": "https://example.com/product",
+  "store": {
+    "settings": {
+      "scraper_service": "http",
+      "cookies": "sessionid=abc123"
+    },
+    "scrape_strategy": {
+      "title": { "type": "selector", "value": "meta[property=\"og:title\"]|content" },
+      "price": { "type": "selector", "value": "meta[property=\"og:price:amount\"]|content" },
+      "image": { "type": "selector", "value": "meta[property=\"og:image\"]|content" }
+    }
+  }
+}
+```
+
+The response shape is:
+
+```json
+{
+  "data": {
+    "title": "Example product",
+    "price": 35.0,
+    "image": "https://example.com/image.jpg"
+  }
+}
+```
+
+The `price` field is normalized to a numeric value in both the store-backed and auto-create paths.

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,8 +1,13 @@
 <?php
 
+use App\Http\Controllers\Api\MetaExtractionController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/user', function (Request $request) {
     return $request->user()->only(['id', 'name', 'email']);
 })->middleware('auth:sanctum')->name('api.user');
+
+Route::post('/meta-extraction', MetaExtractionController::class)
+    ->middleware('auth:sanctum')
+    ->name('api.meta-extraction');

--- a/tests/Feature/Api/MetaExtractionApiTest.php
+++ b/tests/Feature/Api/MetaExtractionApiTest.php
@@ -8,7 +8,6 @@ use App\Services\AiService;
 use App\Services\Helpers\SettingsHelper;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Once;
 use Jez500\WebScraperForLaravel\Facades\WebScraper;
 use Jez500\WebScraperForLaravel\WebScraperFake;

--- a/tests/Feature/Api/MetaExtractionApiTest.php
+++ b/tests/Feature/Api/MetaExtractionApiTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Tests\Traits\ScraperTrait;
+
+class MetaExtractionApiTest extends TestCase
+{
+    use RefreshDatabase;
+    use ScraperTrait;
+
+    protected User $user;
+
+    protected string $url = 'https://example.com/product/123';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $token = $this->user->createToken('test-token')->plainTextToken;
+        $this->withHeaders(['Authorization' => 'Bearer '.$token]);
+    }
+
+    public function test_can_extract_meta_using_domain_store_configuration(): void
+    {
+        Store::factory()->create([
+            'user_id' => $this->user->id,
+            'domains' => [
+                ['domain' => parse_url($this->url, PHP_URL_HOST)],
+            ],
+            'settings' => [
+                'scraper_service' => 'http',
+                'scraper_service_settings' => '',
+            ],
+            'scrape_strategy' => [
+                'title' => [
+                    'type' => 'selector',
+                    'value' => 'meta[property="og:title"]|content',
+                ],
+                'price' => [
+                    'type' => 'selector',
+                    'value' => 'meta[property="og:price:amount"]|content',
+                ],
+                'image' => [
+                    'type' => 'selector',
+                    'value' => 'meta[property="og:image"]|content',
+                ],
+            ],
+        ]);
+
+        $this->mockScrape('$35.00', 'Example product', 'https://example.com/image.jpg');
+
+        $response = $this->postJson('/api/meta-extraction', [
+            'url' => $this->url,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', 'Example product')
+            ->assertJsonPath('data.price', 35)
+            ->assertJsonPath('data.image', 'https://example.com/image.jpg');
+    }
+
+    public function test_can_extract_meta_using_store_override(): void
+    {
+        $this->mockScrape('$19.99', 'Override product', 'https://example.com/override.jpg');
+
+        $response = $this->postJson('/api/meta-extraction', [
+            'url' => $this->url,
+            'store' => [
+                'settings' => [
+                    'scraper_service' => 'http',
+                    'scraper_service_settings' => '',
+                ],
+                'scrape_strategy' => [
+                    'title' => [
+                        'type' => 'selector',
+                        'value' => 'meta[property="og:title"]|content',
+                    ],
+                    'price' => [
+                        'type' => 'selector',
+                        'value' => 'meta[property="og:price:amount"]|content',
+                    ],
+                    'image' => [
+                        'type' => 'selector',
+                        'value' => 'meta[property="og:image"]|content',
+                    ],
+                ],
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', 'Override product')
+            ->assertJsonPath('data.price', 19.99)
+            ->assertJsonPath('data.image', 'https://example.com/override.jpg');
+    }
+
+    public function test_can_extract_meta_using_schema_org_strategies_with_null_values(): void
+    {
+        $this->mockScrapeSchema('$42.50', 'Schema product', 'https://example.com/schema.jpg');
+
+        $response = $this->postJson('/api/meta-extraction', [
+            'url' => $this->url,
+            'store' => [
+                'settings' => [
+                    'scraper_service' => 'http',
+                    'scraper_service_settings' => '',
+                ],
+                'scrape_strategy' => [
+                    'title' => [
+                        'type' => 'schema_org',
+                        'value' => null,
+                    ],
+                    'price' => [
+                        'type' => 'schema_org',
+                        'value' => null,
+                    ],
+                    'image' => [
+                        'type' => 'schema_org',
+                        'value' => null,
+                    ],
+                ],
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', 'Schema product')
+            ->assertJsonPath('data.price', 42.5)
+            ->assertJsonPath('data.image', 'https://example.com/schema.jpg');
+    }
+
+    public function test_auto_create_path_normalizes_the_price_output(): void
+    {
+        $this->mockScrape('$35.00', 'Example product', 'https://example.com/image.jpg');
+
+        $response = $this->postJson('/api/meta-extraction', [
+            'url' => $this->url,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', 'Example product')
+            ->assertJsonPath('data.price', 35)
+            ->assertJsonPath('data.image', 'https://example.com/image.jpg');
+    }
+
+    public function test_validation_fails_without_a_url(): void
+    {
+        $response = $this->postJson('/api/meta-extraction', []);
+
+        $response->assertUnprocessable()
+            ->assertJsonValidationErrors(['url']);
+    }
+}

--- a/tests/Feature/Api/MetaExtractionApiTest.php
+++ b/tests/Feature/Api/MetaExtractionApiTest.php
@@ -147,6 +147,31 @@ class MetaExtractionApiTest extends TestCase
             ->assertJsonPath('data.image', 'https://example.com/image.jpg');
     }
 
+    public function test_auto_create_path_returns_the_detected_store(): void
+    {
+        $this->mockScrape('$35.00', 'Example product', 'https://example.com/image.jpg');
+
+        $response = $this->postJson('/api/meta-extraction', [
+            'url' => $this->url,
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', 'Example product')
+            ->assertJsonStructure([
+                'data' => [
+                    'store' => [
+                        'name',
+                        'domains',
+                        'scrape_settings' => ['title', 'price'],
+                    ],
+                ],
+            ])
+            ->assertJsonPath('data.store.name', 'Example.com');
+
+        $domains = collect($response->json('data.store.domains'))->pluck('domain');
+        $this->assertTrue($domains->contains('example.com'));
+    }
+
     public function test_validation_fails_without_a_url(): void
     {
         $response = $this->postJson('/api/meta-extraction', []);

--- a/tests/Feature/Api/MetaExtractionApiTest.php
+++ b/tests/Feature/Api/MetaExtractionApiTest.php
@@ -306,6 +306,40 @@ class MetaExtractionApiTest extends TestCase
         $response->assertOk()->assertJsonPath('data.price', null);
     }
 
+    public function test_auto_create_path_heals_via_the_agent_and_returns_a_store(): void
+    {
+        $this->configureProviders();
+        $this->fakeHtml($this->healHtml());
+        $this->mockAgent([
+            'is_product' => true,
+            'fields' => [
+                'title' => ['type' => 'selector', 'value' => '.t'],
+                'price' => ['type' => 'selector', 'value' => '#pr'],
+            ],
+        ]);
+
+        // No store in the DB for this domain, no override -> auto-create path.
+        $response = $this->postJson('/api/meta-extraction', ['url' => $this->url]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', 'Widget')
+            ->assertJsonPath('data.price', 12.99)
+            ->assertJsonPath('data.store.name', 'Example.com')
+            ->assertJsonPath('data.store.scrape_settings.price.value', '#pr');
+    }
+
+    public function test_auto_create_path_without_healing_returns_an_empty_store(): void
+    {
+        $this->configureProviders(['feature_providers' => ['healing' => '__disabled__']]);
+        $this->fakeHtml($this->healHtml());
+        $this->mockAgent([], 'never');
+
+        $response = $this->postJson('/api/meta-extraction', ['url' => $this->url]);
+
+        $response->assertOk();
+        $this->assertEmpty($response->json('data.store'));
+    }
+
     private function configureProviders(array $aiOverrides = []): void
     {
         SettingsHelper::setSetting('integrated_services', ['ai' => array_merge([

--- a/tests/Feature/Api/MetaExtractionApiTest.php
+++ b/tests/Feature/Api/MetaExtractionApiTest.php
@@ -154,4 +154,13 @@ class MetaExtractionApiTest extends TestCase
         $response->assertUnprocessable()
             ->assertJsonValidationErrors(['url']);
     }
+
+    public function test_validation_rejects_internal_and_non_http_urls(): void
+    {
+        foreach (['http://169.254.169.254/latest/meta-data/', 'http://127.0.0.1/', 'file:///etc/passwd'] as $url) {
+            $this->postJson('/api/meta-extraction', ['url' => $url])
+                ->assertUnprocessable()
+                ->assertJsonValidationErrors(['url']);
+        }
+    }
 }

--- a/tests/Feature/Api/MetaExtractionApiTest.php
+++ b/tests/Feature/Api/MetaExtractionApiTest.php
@@ -4,7 +4,14 @@ namespace Tests\Feature\Api;
 
 use App\Models\Store;
 use App\Models\User;
+use App\Services\AiService;
+use App\Services\Helpers\SettingsHelper;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Once;
+use Jez500\WebScraperForLaravel\Facades\WebScraper;
+use Jez500\WebScraperForLaravel\WebScraperFake;
 use Tests\TestCase;
 use Tests\Traits\ScraperTrait;
 
@@ -24,6 +31,10 @@ class MetaExtractionApiTest extends TestCase
         $this->user = User::factory()->create();
         $token = $this->user->createToken('test-token')->plainTextToken;
         $this->withHeaders(['Authorization' => 'Bearer '.$token]);
+
+        SettingsHelper::$settings = null;
+        Cache::flush();
+        Once::flush();
     }
 
     public function test_can_extract_meta_using_domain_store_configuration(): void
@@ -187,5 +198,146 @@ class MetaExtractionApiTest extends TestCase
                 ->assertUnprocessable()
                 ->assertJsonValidationErrors(['url']);
         }
+    }
+
+    public function test_heals_an_existing_store_via_the_agent_when_scrape_finds_no_price(): void
+    {
+        $this->configureProviders();
+        $this->fakeHtml($this->healHtml());
+        $this->mockAgent([
+            'is_product' => true,
+            'fields' => [
+                'title' => ['type' => 'selector', 'value' => '.t'],
+                'price' => ['type' => 'selector', 'value' => '#pr'],
+            ],
+        ]);
+
+        Store::factory()->create([
+            'user_id' => $this->user->id,
+            'domains' => [['domain' => parse_url($this->url, PHP_URL_HOST)]],
+            'scrape_strategy' => [],
+            'settings' => ['scraper_service' => 'http'],
+        ]);
+
+        $response = $this->postJson('/api/meta-extraction', ['url' => $this->url]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', 'Widget')
+            ->assertJsonPath('data.price', 12.99)
+            ->assertJsonPath('data.store.scrape_settings.price.value', '#pr');
+    }
+
+    public function test_heals_an_existing_store_deterministically_without_the_agent(): void
+    {
+        $this->configureProviders();
+        $this->mockScrape('$35.00', 'Example product', 'https://example.com/image.jpg');
+        $this->mockAgent([], 'never');
+
+        Store::factory()->create([
+            'user_id' => $this->user->id,
+            'domains' => [['domain' => parse_url($this->url, PHP_URL_HOST)]],
+            'scrape_strategy' => [
+                'price' => ['type' => 'selector', 'value' => '.no-such-price'],
+            ],
+            'settings' => ['scraper_service' => 'http'],
+        ]);
+
+        $response = $this->postJson('/api/meta-extraction', ['url' => $this->url]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.price', 35)
+            ->assertJsonStructure(['data' => ['store' => ['scrape_settings' => ['price']]]]);
+    }
+
+    public function test_does_not_heal_when_the_scrape_already_found_a_price(): void
+    {
+        $this->configureProviders();
+        $this->mockScrape('$35.00', 'Example product', 'https://example.com/image.jpg');
+        $this->mockAgent([], 'never');
+
+        Store::factory()->create([
+            'user_id' => $this->user->id,
+            'domains' => [['domain' => parse_url($this->url, PHP_URL_HOST)]],
+            'settings' => ['scraper_service' => 'http'],
+            'scrape_strategy' => [
+                'title' => ['type' => 'selector', 'value' => 'meta[property="og:title"]|content'],
+                'price' => ['type' => 'selector', 'value' => 'meta[property="og:price:amount"]|content'],
+                'image' => ['type' => 'selector', 'value' => 'meta[property="og:image"]|content'],
+            ],
+        ]);
+
+        $response = $this->postJson('/api/meta-extraction', ['url' => $this->url]);
+
+        $response->assertOk()->assertJsonPath('data.price', 35);
+    }
+
+    public function test_does_not_heal_when_store_opted_out(): void
+    {
+        $this->configureProviders();
+        $this->fakeHtml($this->healHtml());
+        $this->mockAgent([], 'never');
+
+        Store::factory()->create([
+            'user_id' => $this->user->id,
+            'domains' => [['domain' => parse_url($this->url, PHP_URL_HOST)]],
+            'scrape_strategy' => [],
+            'settings' => ['scraper_service' => 'http', 'ai_self_healing_disabled' => true],
+        ]);
+
+        $response = $this->postJson('/api/meta-extraction', ['url' => $this->url]);
+
+        $response->assertOk()->assertJsonPath('data.price', null);
+    }
+
+    public function test_does_not_heal_when_healing_feature_is_disabled(): void
+    {
+        $this->configureProviders(['feature_providers' => ['healing' => '__disabled__']]);
+        $this->fakeHtml($this->healHtml());
+        $this->mockAgent([], 'never');
+
+        Store::factory()->create([
+            'user_id' => $this->user->id,
+            'domains' => [['domain' => parse_url($this->url, PHP_URL_HOST)]],
+            'scrape_strategy' => [],
+            'settings' => ['scraper_service' => 'http'],
+        ]);
+
+        $response = $this->postJson('/api/meta-extraction', ['url' => $this->url]);
+
+        $response->assertOk()->assertJsonPath('data.price', null);
+    }
+
+    private function configureProviders(array $aiOverrides = []): void
+    {
+        SettingsHelper::setSetting('integrated_services', ['ai' => array_merge([
+            'enabled' => true,
+            'default_provider_id' => 'p1',
+            'providers' => [[
+                'id' => 'p1', 'name' => 'Local', 'type' => 'ollama',
+                'base_url' => 'http://ai.example:11434', 'model' => 'm',
+            ]],
+        ], $aiOverrides)]);
+        SettingsHelper::$settings = null;
+        Cache::flush();
+        Once::flush();
+    }
+
+    private function mockAgent(?array $proposal, string $expectation = 'once'): void
+    {
+        $this->mock(AiService::class, fn ($m) => $m->shouldReceive('runAgent')->{$expectation}()->andReturn($proposal));
+    }
+
+    /**
+     * HTML the deterministic heuristics do NOT recognise, but a `.t` / `#pr` selector does,
+     * so the mocked agent path is exercised.
+     */
+    private function healHtml(): string
+    {
+        return '<html><body><div class="t">Widget</div><span id="pr">$12.99</span></body></html>';
+    }
+
+    private function fakeHtml(string $html): void
+    {
+        WebScraper::shouldReceive('make')->andReturn((new WebScraperFake)->setBody($html));
     }
 }

--- a/tests/Feature/Api/MetaExtractionApiTest.php
+++ b/tests/Feature/Api/MetaExtractionApiTest.php
@@ -306,6 +306,37 @@ class MetaExtractionApiTest extends TestCase
         $response->assertOk()->assertJsonPath('data.price', null);
     }
 
+    public function test_heals_a_store_override_when_scrape_finds_no_price(): void
+    {
+        $this->configureProviders();
+        $this->fakeHtml($this->healHtml());
+        $this->mockAgent([
+            'is_product' => true,
+            'fields' => [
+                'title' => ['type' => 'selector', 'value' => '.t'],
+                'price' => ['type' => 'selector', 'value' => '#pr'],
+            ],
+        ]);
+
+        // Override store with selectors that miss on the page -> no price -> heal.
+        $response = $this->postJson('/api/meta-extraction', [
+            'url' => $this->url,
+            'store' => [
+                'settings' => ['scraper_service' => 'http', 'scraper_service_settings' => ''],
+                'scrape_strategy' => [
+                    'title' => ['type' => 'selector', 'value' => '.nope-title'],
+                    'price' => ['type' => 'selector', 'value' => '.nope-price'],
+                    'image' => ['type' => 'selector', 'value' => '.nope-image'],
+                ],
+            ],
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.title', 'Widget')
+            ->assertJsonPath('data.price', 12.99)
+            ->assertJsonPath('data.store.scrape_settings.price.value', '#pr');
+    }
+
     public function test_auto_create_path_heals_via_the_agent_and_returns_a_store(): void
     {
         $this->configureProviders();

--- a/tests/Feature/Filament/StoreSelfHealUiTest.php
+++ b/tests/Feature/Filament/StoreSelfHealUiTest.php
@@ -99,7 +99,10 @@ class StoreSelfHealUiTest extends TestCase
             ->assertSet('healPreview', null);
 
         // Nothing persisted until the user clicks Save.
-        $this->assertSame([], $store->fresh()->scrape_strategy);
+        $fresh = $store->fresh()->scrape_strategy;
+        $this->assertNull($fresh->price);
+        $this->assertNull($fresh->title);
+        $this->assertNull($fresh->availability);
         $this->assertSame('http', data_get($store->fresh()->settings, 'scraper_service'));
     }
 

--- a/tests/Feature/Filament/StoreStrategyDtoBridgeTest.php
+++ b/tests/Feature/Filament/StoreStrategyDtoBridgeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\StoreResource\Pages\EditStore;
+use App\Models\Store;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class StoreStrategyDtoBridgeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        User::query()->delete();
+
+        $this->user = User::factory()->create([
+            'name' => 'Tester',
+            'email' => 'tester@test.com',
+            'password' => Hash::make('password'),
+        ]);
+    }
+
+    public function test_edit_fill_from_dto_populates_form_fields(): void
+    {
+        $store = Store::factory()->create([
+            'scrape_strategy' => [
+                'title' => ['type' => 'selector', 'value' => 'h1.title'],
+                'price' => ['type' => 'selector', 'value' => '.price'],
+                'image' => ['type' => 'selector', 'value' => 'img|src'],
+            ],
+        ]);
+
+        $this->actingAs($this->user);
+
+        Livewire::test(EditStore::class, ['record' => $store->getKey()])
+            ->assertFormSet(fn (array $state): bool => data_get($state, 'scrape_strategy.title.type') === 'selector'
+                && data_get($state, 'scrape_strategy.title.value') === 'h1.title'
+                && data_get($state, 'scrape_strategy.price.value') === '.price'
+            );
+    }
+
+    public function test_edit_save_persists_strategy_via_dto(): void
+    {
+        $store = Store::factory()->create([
+            'scrape_strategy' => [
+                'title' => ['type' => 'selector', 'value' => 'h1.old'],
+                'price' => ['type' => 'selector', 'value' => '.price'],
+                'image' => ['type' => 'selector', 'value' => 'img|src'],
+            ],
+        ]);
+
+        $this->actingAs($this->user);
+
+        Livewire::test(EditStore::class, ['record' => $store->getKey()])
+            ->set('data.domains', null)
+            ->fillForm([
+                'name' => $store->name,
+                'domains' => [
+                    ['domain' => 'example.com'],
+                ],
+                'settings.locale_settings.locale' => 'en_US',
+                'settings.locale_settings.currency' => 'USD',
+                'scrape_strategy.title.value' => 'h2.new',
+                'scrape_strategy.title.type' => 'selector',
+                'scrape_strategy.price.value' => '.price',
+                'scrape_strategy.price.type' => 'selector',
+                'scrape_strategy.image.value' => 'img|src',
+                'scrape_strategy.image.type' => 'selector',
+            ])
+            ->call('save')
+            ->assertHasNoFormErrors();
+
+        $store->refresh();
+
+        $this->assertSame('h2.new', $store->scrape_strategy->title->value);
+    }
+}

--- a/tests/Feature/Models/StoreScrapeStrategyCastTest.php
+++ b/tests/Feature/Models/StoreScrapeStrategyCastTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests\Feature\Models;
+
+use App\Dto\StoreScraperStrategySetDto;
+use App\Models\Store;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StoreScrapeStrategyCastTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_returns_a_strategy_set_dto_from_the_scrape_strategy_attribute(): void
+    {
+        $store = Store::factory()->create([
+            'scrape_strategy' => [
+                'title' => ['type' => 'selector', 'value' => 'h1'],
+                'price' => ['type' => 'selector', 'value' => '.price'],
+            ],
+        ]);
+
+        $store->refresh();
+
+        $this->assertInstanceOf(StoreScraperStrategySetDto::class, $store->scrape_strategy);
+        $this->assertSame('h1', $store->scrape_strategy->title->value);
+        $this->assertSame('.price', $store->scrape_strategy->price->value);
+    }
+
+    public function test_serializes_back_to_the_original_nested_array_shape(): void
+    {
+        $strategy = [
+            'title' => ['type' => 'selector', 'value' => 'title'],
+            'price' => ['type' => 'selector', 'value' => '.a-price > .a-offscreen'],
+            'image' => ['type' => 'regex', 'value' => '~"hiRes":"(.+?)"~'],
+        ];
+
+        $store = Store::factory()->create(['scrape_strategy' => $strategy]);
+
+        $this->assertEquals($strategy, $store->toArray()['scrape_strategy']);
+    }
+
+    public function test_stores_the_canonical_json_in_the_database_column(): void
+    {
+        $store = Store::factory()->create([
+            'scrape_strategy' => ['title' => ['type' => 'selector', 'value' => 'h1']],
+        ]);
+
+        $raw = json_decode($store->getRawOriginal('scrape_strategy'), true);
+
+        $this->assertEquals(['title' => ['type' => 'selector', 'value' => 'h1']], $raw);
+    }
+}

--- a/tests/Feature/Models/UrlTest.php
+++ b/tests/Feature/Models/UrlTest.php
@@ -174,7 +174,7 @@ class UrlTest extends TestCase
         $this->actingAs($this->user);
 
         $this->store->update([
-            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+            'scrape_strategy' => array_merge($this->store->scrape_strategy->toArray(), [
                 'availability' => [
                     'type' => 'selector',
                     'value' => '.availability',
@@ -207,7 +207,7 @@ class UrlTest extends TestCase
         ]);
 
         $this->store->update([
-            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+            'scrape_strategy' => array_merge($this->store->scrape_strategy->toArray(), [
                 'availability' => [
                     'type' => 'selector',
                     'value' => '.availability',
@@ -251,7 +251,7 @@ class UrlTest extends TestCase
         ]);
 
         $this->store->update([
-            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+            'scrape_strategy' => array_merge($this->store->scrape_strategy->toArray(), [
                 'availability' => [
                     'type' => 'selector',
                     'value' => '.availability',
@@ -292,7 +292,7 @@ class UrlTest extends TestCase
         ]);
 
         $this->store->update([
-            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+            'scrape_strategy' => array_merge($this->store->scrape_strategy->toArray(), [
                 'availability' => [
                     'type' => 'selector',
                     'value' => '.availability',
@@ -322,7 +322,7 @@ class UrlTest extends TestCase
         ]);
 
         $this->store->update([
-            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+            'scrape_strategy' => array_merge($this->store->scrape_strategy->toArray(), [
                 'availability' => [
                     'type' => 'selector',
                     'value' => '.availability',
@@ -428,7 +428,7 @@ class UrlTest extends TestCase
     protected function setAvailabilityStrategy(): void
     {
         $this->store->update([
-            'scrape_strategy' => array_merge($this->store->scrape_strategy ?? [], [
+            'scrape_strategy' => array_merge($this->store->scrape_strategy->toArray(), [
                 'availability' => [
                     'type' => 'selector',
                     'value' => '.availability',

--- a/tests/Feature/Services/AiConfigHealerTest.php
+++ b/tests/Feature/Services/AiConfigHealerTest.php
@@ -248,4 +248,27 @@ class AiConfigHealerTest extends TestCase
         $this->assertSame([], $url->store->fresh()->scrape_strategy->toArray());
         $this->assertNotNull($url->store->fresh()->getAiHealFailedAt());
     }
+
+    public function test_apply_preview_to_store_merges_fields_in_memory_without_saving(): void
+    {
+        $store = Store::factory()->create([
+            'scrape_strategy' => ['image' => ['type' => 'selector', 'value' => 'img|src']],
+            'settings' => ['scraper_service' => 'http'],
+        ]);
+
+        AiConfigHealer::new()->applyPreviewToStore($store, [
+            'fields' => ['price' => ['type' => 'selector', 'value' => '#pr']],
+            'usedBrowser' => true,
+        ]);
+
+        // In memory: merged with the existing field, switched to the browser scraper.
+        $this->assertSame('#pr', data_get($store->scrape_strategy, 'price.value'));
+        $this->assertSame('img|src', data_get($store->scrape_strategy, 'image.value'));
+        $this->assertSame('api', data_get($store->settings, 'scraper_service'));
+
+        // Not persisted: the DB row is unchanged.
+        $fresh = $store->fresh();
+        $this->assertSame(['image' => ['type' => 'selector', 'value' => 'img|src']], $fresh->scrape_strategy->toArray());
+        $this->assertSame('http', data_get($fresh->settings, 'scraper_service'));
+    }
 }

--- a/tests/Feature/Services/AiConfigHealerTest.php
+++ b/tests/Feature/Services/AiConfigHealerTest.php
@@ -201,7 +201,7 @@ class AiConfigHealerTest extends TestCase
         $result = AiConfigHealer::new()->heal($url, ['price' => null, 'body' => $this->html(), 'availability' => null]);
 
         $this->assertNull($result['price']);
-        $this->assertSame([], $url->store->fresh()->scrape_strategy);
+        $this->assertSame([], $url->store->fresh()->scrape_strategy->toArray());
         $this->assertNotNull($url->store->fresh()->getAiHealFailedAt());
     }
 
@@ -232,7 +232,7 @@ class AiConfigHealerTest extends TestCase
         $result = AiConfigHealer::new()->heal($url, ['price' => null, 'body' => $this->html(), 'availability' => null]);
 
         $this->assertNull($result['price']);
-        $this->assertSame([], $url->store->fresh()->scrape_strategy);
+        $this->assertSame([], $url->store->fresh()->scrape_strategy->toArray());
         $this->assertNotNull($url->store->fresh()->getAiHealFailedAt());
     }
 
@@ -245,7 +245,7 @@ class AiConfigHealerTest extends TestCase
         $result = AiConfigHealer::new()->heal($url, ['price' => null, 'body' => $this->html(), 'availability' => null]);
 
         $this->assertNull($result['price']);
-        $this->assertSame([], $url->store->fresh()->scrape_strategy);
+        $this->assertSame([], $url->store->fresh()->scrape_strategy->toArray());
         $this->assertNotNull($url->store->fresh()->getAiHealFailedAt());
     }
 }

--- a/tests/Feature/Services/DeterministicHealTest.php
+++ b/tests/Feature/Services/DeterministicHealTest.php
@@ -62,9 +62,9 @@ class DeterministicHealTest extends TestCase
         $store = AiConfigHealer::new()->healStoreForUrl('https://shop.test/widget', null, $this->schemaOrgHtml());
 
         $this->assertInstanceOf(Store::class, $store);
-        $this->assertSame('schema_org', data_get($store->scrape_strategy, 'price.type'));
-        $this->assertSame('schema_org', data_get($store->scrape_strategy, 'availability.type'));
-        $this->assertSame('schema_org', data_get($store->scrape_strategy, 'title.type'));
+        $this->assertSame('schema_org', $store->scrape_strategy->price?->type->value);
+        $this->assertSame('schema_org', $store->scrape_strategy->availability?->type->value);
+        $this->assertSame('schema_org', $store->scrape_strategy->title?->type->value);
     }
 
     public function test_preview_returns_schema_org_fields_without_invoking_the_agent(): void
@@ -95,6 +95,6 @@ class DeterministicHealTest extends TestCase
 
         $this->assertInstanceOf(Store::class, $store);
         $this->assertSame('api', data_get($store->settings, 'scraper_service'));
-        $this->assertSame('schema_org', data_get($store->scrape_strategy, 'price.type'));
+        $this->assertSame('schema_org', $store->scrape_strategy->price?->type->value);
     }
 }

--- a/tests/Feature/Services/SchemaOrgAvailabilityTest.php
+++ b/tests/Feature/Services/SchemaOrgAvailabilityTest.php
@@ -2,7 +2,6 @@
 
 namespace Tests\Feature\Services;
 
-use App\Dto\AvailabilityStrategyDto;
 use App\Enums\StockStatus;
 use App\Models\Store;
 use App\Services\ScrapeUrl;

--- a/tests/Feature/Services/SchemaOrgAvailabilityTest.php
+++ b/tests/Feature/Services/SchemaOrgAvailabilityTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Services;
 
+use App\Dto\AvailabilityStrategyDto;
 use App\Enums\StockStatus;
 use App\Models\Store;
 use App\Services\ScrapeUrl;

--- a/tests/Unit/Casts/StoreScraperStrategySetCastTest.php
+++ b/tests/Unit/Casts/StoreScraperStrategySetCastTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Unit\Casts;
+
+use App\Casts\StoreScraperStrategySetCast;
+use App\Dto\StoreScraperStrategySetDto;
+use App\Models\Store;
+use PHPUnit\Framework\TestCase;
+
+class StoreScraperStrategySetCastTest extends TestCase
+{
+    private StoreScraperStrategySetCast $cast;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->cast = new StoreScraperStrategySetCast;
+    }
+
+    public function test_get_returns_dto_from_json(): void
+    {
+        $json = json_encode(['title' => ['type' => 'selector', 'value' => 'h1']]);
+
+        $dto = $this->cast->get(new Store, 'scrape_strategy', $json, []);
+
+        $this->assertInstanceOf(StoreScraperStrategySetDto::class, $dto);
+        $this->assertSame('h1', $dto->title->value);
+    }
+
+    public function test_get_returns_empty_dto_for_null(): void
+    {
+        $dto = $this->cast->get(new Store, 'scrape_strategy', null, []);
+
+        $this->assertInstanceOf(StoreScraperStrategySetDto::class, $dto);
+        $this->assertNull($dto->title);
+    }
+
+    public function test_set_accepts_array_and_dto_identically(): void
+    {
+        $array = ['title' => ['type' => 'selector', 'value' => 'h1']];
+        $dto = StoreScraperStrategySetDto::fromArray($array);
+
+        $fromArray = $this->cast->set(new Store, 'scrape_strategy', $array, []);
+        $fromDto = $this->cast->set(new Store, 'scrape_strategy', $dto, []);
+
+        $this->assertSame($fromArray, $fromDto);
+        $this->assertSame(json_encode(['title' => ['type' => 'selector', 'value' => 'h1']]), $fromArray);
+    }
+
+    public function test_set_handles_null(): void
+    {
+        $this->assertNull($this->cast->set(new Store, 'scrape_strategy', null, []));
+    }
+}

--- a/tests/Unit/Dto/AvailabilityMatchDtoTest.php
+++ b/tests/Unit/Dto/AvailabilityMatchDtoTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit\Dto;
+
+use App\Dto\AvailabilityMatchDto;
+use App\Enums\AvailabilityMatchType;
+use PHPUnit\Framework\TestCase;
+
+class AvailabilityMatchDtoTest extends TestCase
+{
+    public function test_from_array_builds_dto(): void
+    {
+        $dto = AvailabilityMatchDto::fromArray(['type' => 'regex', 'value' => 'sold.?out']);
+
+        $this->assertSame(AvailabilityMatchType::Regex, $dto->type);
+        $this->assertSame('sold.?out', $dto->value);
+    }
+
+    public function test_from_array_defaults_type_to_match(): void
+    {
+        $dto = AvailabilityMatchDto::fromArray(['value' => 'Sold out']);
+
+        $this->assertSame(AvailabilityMatchType::Match, $dto->type);
+    }
+
+    public function test_from_array_returns_null_when_value_blank(): void
+    {
+        $this->assertNull(AvailabilityMatchDto::fromArray(null));
+        $this->assertNull(AvailabilityMatchDto::fromArray(['type' => 'match', 'value' => '']));
+        $this->assertNull(AvailabilityMatchDto::fromArray(['type' => 'match']));
+    }
+
+    public function test_to_array_round_trips(): void
+    {
+        $this->assertEquals(
+            ['type' => 'match', 'value' => 'Sold out'],
+            AvailabilityMatchDto::fromArray(['type' => 'match', 'value' => 'Sold out'])->toArray(),
+        );
+    }
+}

--- a/tests/Unit/Dto/AvailabilityStrategyDtoTest.php
+++ b/tests/Unit/Dto/AvailabilityStrategyDtoTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Tests\Unit\Dto;
+
+use App\Dto\AvailabilityMatchDto;
+use App\Dto\AvailabilityStrategyDto;
+use App\Enums\ScraperStrategyType;
+use App\Enums\StockStatus;
+use PHPUnit\Framework\TestCase;
+
+class AvailabilityStrategyDtoTest extends TestCase
+{
+    public function test_from_array_splits_match_and_default(): void
+    {
+        $dto = AvailabilityStrategyDto::fromArray([
+            'type' => 'selector',
+            'value' => '#avail',
+            'match' => [
+                'out_of_stock' => ['type' => 'match', 'value' => 'Sold out'],
+                'pre_order' => ['type' => 'regex', 'value' => 'pre.?order'],
+                'default' => 'in_stock',
+            ],
+        ]);
+
+        $this->assertSame(ScraperStrategyType::Selector, $dto->type);
+        $this->assertSame('#avail', $dto->value);
+        $this->assertSame(StockStatus::InStock, $dto->defaultStatus);
+        $this->assertInstanceOf(AvailabilityMatchDto::class, $dto->match['out_of_stock']);
+        $this->assertSame('Sold out', $dto->match['out_of_stock']->value);
+        $this->assertArrayNotHasKey('default', $dto->match);
+    }
+
+    public function test_from_array_without_match(): void
+    {
+        $dto = AvailabilityStrategyDto::fromArray(['type' => 'selector', 'value' => '#avail']);
+
+        $this->assertSame([], $dto->match);
+        $this->assertSame(StockStatus::InStock, $dto->defaultStatus);
+        $this->assertNull($dto->matchConfig());
+    }
+
+    public function test_match_config_rebuilds_legacy_array(): void
+    {
+        $dto = AvailabilityStrategyDto::fromArray([
+            'type' => 'selector',
+            'match' => [
+                'out_of_stock' => ['type' => 'match', 'value' => 'Sold out'],
+                'default' => 'in_stock',
+            ],
+        ]);
+
+        $this->assertEquals([
+            'out_of_stock' => ['type' => 'match', 'value' => 'Sold out'],
+            'default' => 'in_stock',
+        ], $dto->matchConfig());
+    }
+
+    public function test_to_array_round_trips(): void
+    {
+        $input = [
+            'type' => 'selector',
+            'value' => '#avail',
+            'match' => [
+                'out_of_stock' => ['type' => 'match', 'value' => 'Sold out'],
+                'default' => 'in_stock',
+            ],
+        ];
+
+        $this->assertEquals($input, AvailabilityStrategyDto::fromArray($input)->toArray());
+    }
+
+    public function test_to_array_omits_empty_match(): void
+    {
+        $this->assertEquals(
+            ['type' => 'selector', 'value' => '#avail'],
+            AvailabilityStrategyDto::fromArray(['type' => 'selector', 'value' => '#avail'])->toArray(),
+        );
+    }
+}

--- a/tests/Unit/Dto/AvailabilityStrategyDtoTest.php
+++ b/tests/Unit/Dto/AvailabilityStrategyDtoTest.php
@@ -76,4 +76,23 @@ class AvailabilityStrategyDtoTest extends TestCase
             AvailabilityStrategyDto::fromArray(['type' => 'selector', 'value' => '#avail'])->toArray(),
         );
     }
+
+    public function test_from_array_normalizes_legacy_plain_string_match_entries(): void
+    {
+        $dto = AvailabilityStrategyDto::fromArray([
+            'type' => 'selector',
+            'value' => '#avail',
+            'match' => [
+                'out_of_stock' => 'Sold out',
+                'default' => 'in_stock',
+            ],
+        ]);
+
+        $this->assertSame(\App\Enums\AvailabilityMatchType::Match, $dto->match['out_of_stock']->type);
+        $this->assertSame('Sold out', $dto->match['out_of_stock']->value);
+        $this->assertEquals([
+            'out_of_stock' => ['type' => 'match', 'value' => 'Sold out'],
+            'default' => 'in_stock',
+        ], $dto->matchConfig());
+    }
 }

--- a/tests/Unit/Dto/StandardStrategyDtoTest.php
+++ b/tests/Unit/Dto/StandardStrategyDtoTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Unit\Dto;
+
+use App\Dto\StandardStrategyDto;
+use App\Enums\ScraperStrategyType;
+use PHPUnit\Framework\TestCase;
+
+class StandardStrategyDtoTest extends TestCase
+{
+    public function test_from_array_builds_typed_dto(): void
+    {
+        $dto = StandardStrategyDto::fromArray([
+            'type' => 'selector',
+            'value' => '#p',
+            'prepend' => '$',
+            'append' => '0',
+        ]);
+
+        $this->assertSame(ScraperStrategyType::Selector, $dto->type);
+        $this->assertSame('#p', $dto->value);
+        $this->assertSame('$', $dto->prepend);
+        $this->assertSame('0', $dto->append);
+    }
+
+    public function test_from_array_returns_null_for_missing_or_invalid_type(): void
+    {
+        $this->assertNull(StandardStrategyDto::fromArray(null));
+        $this->assertNull(StandardStrategyDto::fromArray([]));
+        $this->assertNull(StandardStrategyDto::fromArray(['type' => '']));
+        $this->assertNull(StandardStrategyDto::fromArray(['type' => 'bogus', 'value' => 'x']));
+    }
+
+    public function test_schema_org_allows_null_value(): void
+    {
+        $dto = StandardStrategyDto::fromArray(['type' => 'schema_org']);
+
+        $this->assertSame(ScraperStrategyType::SchemaOrg, $dto->type);
+        $this->assertNull($dto->value);
+    }
+
+    public function test_blank_strings_normalize_to_null(): void
+    {
+        $dto = StandardStrategyDto::fromArray(['type' => 'selector', 'value' => '', 'prepend' => '', 'append' => '']);
+
+        $this->assertNull($dto->value);
+        $this->assertNull($dto->prepend);
+        $this->assertNull($dto->append);
+    }
+
+    public function test_to_array_emits_only_populated_keys(): void
+    {
+        $this->assertEquals(
+            ['type' => 'selector', 'value' => '#p'],
+            StandardStrategyDto::fromArray(['type' => 'selector', 'value' => '#p'])->toArray(),
+        );
+
+        $this->assertEquals(
+            ['type' => 'selector', 'value' => '#p', 'prepend' => '$', 'append' => '0'],
+            StandardStrategyDto::fromArray(['type' => 'selector', 'value' => '#p', 'prepend' => '$', 'append' => '0'])->toArray(),
+        );
+
+        $this->assertEquals(
+            ['type' => 'schema_org'],
+            StandardStrategyDto::fromArray(['type' => 'schema_org'])->toArray(),
+        );
+    }
+}

--- a/tests/Unit/Dto/StoreScraperStrategySetDtoTest.php
+++ b/tests/Unit/Dto/StoreScraperStrategySetDtoTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit\Dto;
+
+use App\Dto\AvailabilityStrategyDto;
+use App\Dto\StandardStrategyDto;
+use App\Dto\StoreScraperStrategySetDto;
+use PHPUnit\Framework\TestCase;
+
+class StoreScraperStrategySetDtoTest extends TestCase
+{
+    public function test_from_array_builds_typed_slots(): void
+    {
+        $set = StoreScraperStrategySetDto::fromArray([
+            'title' => ['type' => 'selector', 'value' => 'title'],
+            'price' => ['type' => 'selector', 'value' => '.price'],
+            'image' => ['type' => 'regex', 'value' => '~img~'],
+            'description' => ['type' => 'selector', 'value' => '#desc'],
+            'availability' => ['type' => 'selector', 'value' => '#avail'],
+        ]);
+
+        $this->assertInstanceOf(StandardStrategyDto::class, $set->title);
+        $this->assertInstanceOf(StandardStrategyDto::class, $set->description);
+        $this->assertInstanceOf(AvailabilityStrategyDto::class, $set->availability);
+        $this->assertSame('title', $set->title->value);
+    }
+
+    public function test_empty_or_null_yields_all_null_slots(): void
+    {
+        foreach ([StoreScraperStrategySetDto::fromArray(null), StoreScraperStrategySetDto::fromArray([])] as $set) {
+            $this->assertNull($set->title);
+            $this->assertNull($set->price);
+            $this->assertNull($set->image);
+            $this->assertNull($set->description);
+            $this->assertNull($set->availability);
+        }
+    }
+
+    public function test_round_trips_a_seeded_strategy_unchanged(): void
+    {
+        // Mirrors database/seeders/Stores/usa.php (Amazon US).
+        $input = [
+            'title' => ['type' => 'selector', 'value' => 'title'],
+            'price' => ['type' => 'selector', 'value' => '.a-price > .a-offscreen'],
+            'image' => ['type' => 'regex', 'value' => '~"hiRes":"(.+?)"~'],
+        ];
+
+        $this->assertEquals($input, StoreScraperStrategySetDto::fromArray($input)->toArray());
+    }
+
+    public function test_round_trips_full_strategy_with_availability(): void
+    {
+        $input = [
+            'title' => ['type' => 'selector', 'value' => 'title'],
+            'price' => ['type' => 'selector', 'value' => '.price', 'prepend' => '$'],
+            'image' => ['type' => 'regex', 'value' => '~img~'],
+            'description' => ['type' => 'selector', 'value' => '#desc'],
+            'availability' => [
+                'type' => 'selector',
+                'value' => '#avail',
+                'match' => [
+                    'out_of_stock' => ['type' => 'match', 'value' => 'Sold out'],
+                    'default' => 'in_stock',
+                ],
+            ],
+        ];
+
+        $this->assertEquals($input, StoreScraperStrategySetDto::fromArray($input)->toArray());
+    }
+}

--- a/tests/Unit/Enums/AvailabilityMatchTypeTest.php
+++ b/tests/Unit/Enums/AvailabilityMatchTypeTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Unit\Enums;
+
+use App\Enums\AvailabilityMatchType;
+use PHPUnit\Framework\TestCase;
+
+class AvailabilityMatchTypeTest extends TestCase
+{
+    public function test_has_match_and_regex_cases(): void
+    {
+        $this->assertSame('match', AvailabilityMatchType::Match->value);
+        $this->assertSame('regex', AvailabilityMatchType::Regex->value);
+        $this->assertSame(AvailabilityMatchType::Regex, AvailabilityMatchType::tryFrom('regex'));
+        $this->assertNull(AvailabilityMatchType::tryFrom('nope'));
+    }
+}

--- a/tests/Unit/Enums/StockStatusSchemaOrgTest.php
+++ b/tests/Unit/Enums/StockStatusSchemaOrgTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Unit\Enums;
 
+use App\Dto\AvailabilityStrategyDto;
 use App\Enums\StockStatus;
 use PHPUnit\Framework\TestCase;
 
@@ -41,22 +42,22 @@ class StockStatusSchemaOrgTest extends TestCase
     {
         $strategy = ['type' => 'schema_org', 'value' => null];
 
-        $this->assertSame(StockStatus::InStock, StockStatus::resolveAvailability('https://schema.org/InStock', $strategy));
-        $this->assertSame(StockStatus::OutOfStock, StockStatus::resolveAvailability('https://schema.org/OutOfStock', $strategy));
+        $this->assertSame(StockStatus::InStock, StockStatus::resolveAvailability('https://schema.org/InStock', AvailabilityStrategyDto::fromArray($strategy)));
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::resolveAvailability('https://schema.org/OutOfStock', AvailabilityStrategyDto::fromArray($strategy)));
 
         $strategyWithMatch = ['type' => 'schema_org', 'match' => ['out_of_stock' => ['type' => 'match', 'value' => 'InStock']]];
-        $this->assertSame(StockStatus::InStock, StockStatus::resolveAvailability('https://schema.org/InStock', $strategyWithMatch));
+        $this->assertSame(StockStatus::InStock, StockStatus::resolveAvailability('https://schema.org/InStock', AvailabilityStrategyDto::fromArray($strategyWithMatch)));
     }
 
     public function test_resolve_availability_delegates_to_match_for_non_schema_org(): void
     {
         $strategy = ['type' => 'selector', 'match' => ['out_of_stock' => ['type' => 'match', 'value' => 'Sold out']]];
 
-        $this->assertSame(StockStatus::OutOfStock, StockStatus::resolveAvailability('Sold out', $strategy));
-        $this->assertSame(StockStatus::InStock, StockStatus::resolveAvailability(null, $strategy));
+        $this->assertSame(StockStatus::OutOfStock, StockStatus::resolveAvailability('Sold out', AvailabilityStrategyDto::fromArray($strategy)));
+        $this->assertSame(StockStatus::InStock, StockStatus::resolveAvailability(null, AvailabilityStrategyDto::fromArray($strategy)));
         $this->assertSame(
             StockStatus::matchFromScrapedValue('Sold out', $strategy['match']),
-            StockStatus::resolveAvailability('Sold out', $strategy),
+            StockStatus::resolveAvailability('Sold out', AvailabilityStrategyDto::fromArray($strategy)),
         );
     }
 }

--- a/tests/Unit/Rules/PublicHttpUrlTest.php
+++ b/tests/Unit/Rules/PublicHttpUrlTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Unit\Rules;
+
+use App\Rules\PublicHttpUrl;
+use Tests\TestCase;
+
+class PublicHttpUrlTest extends TestCase
+{
+    /**
+     * @return array<string, mixed>
+     */
+    protected function runRule(string $value, ?PublicHttpUrl $rule = null): array
+    {
+        $failures = [];
+
+        ($rule ?? new PublicHttpUrl)->validate('url', $value, function (string $message) use (&$failures): void {
+            $failures[] = $message;
+        });
+
+        return $failures;
+    }
+
+    /**
+     * @dataProvider publicUrls
+     */
+    public function test_it_allows_public_http_urls(string $url): void
+    {
+        $this->assertSame([], $this->runRule($url), "Expected {$url} to be allowed");
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function publicUrls(): array
+    {
+        return [
+            'public ipv4 literal' => ['http://93.184.216.34/'],
+            'public ipv4 literal https' => ['https://1.1.1.1/'],
+            'public ipv6 literal' => ['http://[2606:2800:220:1:248:1893:25c8:1946]/'],
+        ];
+    }
+
+    /**
+     * @dataProvider blockedUrls
+     */
+    public function test_it_blocks_internal_reserved_and_non_http_urls(string $url): void
+    {
+        $this->assertNotEmpty($this->runRule($url), "Expected {$url} to be blocked");
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public static function blockedUrls(): array
+    {
+        return [
+            'ftp scheme' => ['ftp://example.com/'],
+            'file scheme' => ['file:///etc/passwd'],
+            'gopher scheme' => ['gopher://127.0.0.1/'],
+            'no scheme' => ['example.com/path'],
+            'localhost name' => ['http://localhost/'],
+            'localhost subdomain' => ['http://api.localhost/'],
+            'loopback ipv4' => ['http://127.0.0.1/'],
+            'loopback ipv4 range' => ['http://127.1.2.3/'],
+            'loopback ipv6' => ['http://[::1]/'],
+            'unspecified ipv4' => ['http://0.0.0.0/'],
+            'cloud metadata' => ['http://169.254.169.254/latest/meta-data/'],
+            'link local ipv6' => ['http://[fe80::1]/'],
+            'private 10' => ['http://10.0.0.5/'],
+            'private 172' => ['http://172.16.0.1/'],
+            'private 192' => ['http://192.168.1.1/'],
+            'cgnat 100.64' => ['http://100.64.0.1/'],
+            'ula ipv6' => ['http://[fc00::1]/'],
+            'ipv4 mapped loopback' => ['http://[::ffff:127.0.0.1]/'],
+            'broadcast' => ['http://255.255.255.255/'],
+        ];
+    }
+
+    public function test_it_blocks_public_hostnames_that_resolve_to_private_ips(): void
+    {
+        $rule = new class extends PublicHttpUrl
+        {
+            protected function resolveHostIps(string $host): array
+            {
+                return ['10.0.0.20'];
+            }
+        };
+
+        $this->assertNotEmpty($this->runRule('http://internal.example.com/', $rule));
+    }
+
+    public function test_it_blocks_hostnames_that_cannot_be_resolved(): void
+    {
+        $rule = new class extends PublicHttpUrl
+        {
+            protected function resolveHostIps(string $host): array
+            {
+                return [];
+            }
+        };
+
+        $this->assertNotEmpty($this->runRule('http://does-not-resolve.example/', $rule));
+    }
+
+    public function test_it_allows_a_hostname_that_resolves_to_a_public_ip(): void
+    {
+        $rule = new class extends PublicHttpUrl
+        {
+            protected function resolveHostIps(string $host): array
+            {
+                return ['93.184.216.34'];
+            }
+        };
+
+        $this->assertSame([], $this->runRule('http://example.com/', $rule));
+    }
+}

--- a/tests/Unit/Services/AutoCreateStoreMicrodataTest.php
+++ b/tests/Unit/Services/AutoCreateStoreMicrodataTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\AutoCreateStore;
+use Tests\TestCase;
+
+class AutoCreateStoreMicrodataTest extends TestCase
+{
+    private function microdataHtml(): string
+    {
+        return '<html><body><div itemscope itemtype="https://schema.org/Product">'
+            .'<h1 itemprop="name">Premium Leather Boots</h1>'
+            .'<div itemprop="offers" itemscope itemtype="https://schema.org/Offer">'
+            .'<span itemprop="price" content="149.99">149.99</span>'
+            .'</div></div></body></html>';
+    }
+
+    public function test_detects_a_store_strategy_from_microdata(): void
+    {
+        $detected = AutoCreateStore::new('https://shop.test/boots', $this->microdataHtml())
+            ->setLogErrors(false)
+            ->detect();
+
+        $this->assertNotNull($detected);
+        $this->assertSame('schema_org', data_get($detected, 'fields.title.type'));
+        $this->assertSame('schema_org', data_get($detected, 'fields.price.type'));
+        $this->assertSame('Premium Leather Boots', data_get($detected, 'extracted.title'));
+        $this->assertSame(149.99, data_get($detected, 'extracted.price'));
+    }
+}

--- a/tests/Unit/Services/MetaExtractionServiceTest.php
+++ b/tests/Unit/Services/MetaExtractionServiceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Store;
+use App\Services\MetaExtractionService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MetaExtractionServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_override_nested_cookies_are_promoted_to_the_store_model(): void
+    {
+        Store::factory()->create([
+            'domains' => [
+                ['domain' => 'example.com'],
+            ],
+        ]);
+
+        $service = new class extends MetaExtractionService
+        {
+            public function resolveStoreForTest(string $url, array $storeOverride = []): ?Store
+            {
+                return $this->resolveStore($url, $storeOverride);
+            }
+        };
+
+        $store = $service->resolveStoreForTest('https://example.com/product', [
+            'settings' => [
+                'cookies' => 'sessionid=abc123',
+                'scraper_service' => 'http',
+            ],
+        ]);
+
+        $this->assertInstanceOf(Store::class, $store);
+        $this->assertSame('sessionid=abc123', $store->cookies);
+    }
+}

--- a/tests/Unit/Services/SchemaOrgServiceTest.php
+++ b/tests/Unit/Services/SchemaOrgServiceTest.php
@@ -176,6 +176,17 @@ HTML;
         ));
     }
 
+    public function test_parse_microdata_reads_the_data_element_value_attribute(): void
+    {
+        $html = '<div itemscope itemtype="https://schema.org/Product">'
+            .'<span itemprop="name">Widget</span>'
+            .'<div itemprop="offers" itemscope itemtype="https://schema.org/Offer">'
+            .'<data itemprop="price" value="9.99">£9.99</data>'
+            .'</div></div>';
+
+        $this->assertSame('9.99', SchemaOrgService::parseMicrodata($html, 'price'));
+    }
+
     public function test_parse_microdata_does_not_throw_on_malformed_html(): void
     {
         $html = '<div itemscope itemtype="https://schema.org/Product"><span itemprop="name">Broken';

--- a/tests/Unit/Services/SchemaOrgServiceTest.php
+++ b/tests/Unit/Services/SchemaOrgServiceTest.php
@@ -31,6 +31,50 @@ class SchemaOrgServiceTest extends TestCase
         $this->assertEquals('https://example.com/image.jpg', SchemaOrgService::parseSchemaOrg($collection, 'image'));
     }
 
+    public function test_parse_schema_org_image_handles_array_of_image_objects(): void
+    {
+        $jsonLd = [[
+            '@type' => 'Product',
+            'image' => [
+                ['@type' => 'ImageObject', 'url' => 'https://example.com/a.jpg'],
+                ['@type' => 'ImageObject', 'url' => 'https://example.com/b.jpg'],
+            ],
+        ]];
+
+        $this->assertSame('https://example.com/a.jpg', SchemaOrgService::parseSchemaOrg(collect($jsonLd), 'image'));
+    }
+
+    public function test_parse_schema_org_image_handles_single_image_object(): void
+    {
+        $jsonLd = [[
+            '@type' => 'Product',
+            'image' => ['@type' => 'ImageObject', 'url' => 'https://example.com/a.jpg'],
+        ]];
+
+        $this->assertSame('https://example.com/a.jpg', SchemaOrgService::parseSchemaOrg(collect($jsonLd), 'image'));
+    }
+
+    public function test_parse_schema_org_image_returns_null_for_unstringable_structure(): void
+    {
+        $jsonLd = [[
+            '@type' => 'Product',
+            'image' => [['nested' => ['deeper' => 'array']]],
+        ]];
+
+        $this->assertNull(SchemaOrgService::parseSchemaOrg(collect($jsonLd), 'image'));
+    }
+
+    public function test_parse_schema_org_never_returns_an_array_for_a_nested_value(): void
+    {
+        // A name expressed as an unexpected array must not break the ?string contract.
+        $jsonLd = [[
+            '@type' => 'Product',
+            'name' => ['unexpected' => 'array'],
+        ]];
+
+        $this->assertNull(SchemaOrgService::parseSchemaOrg(collect($jsonLd), 'title'));
+    }
+
     public function test_parse_schema_org_handles_different_price_formats()
     {
         // lowPrice

--- a/tests/Unit/Services/SchemaOrgServiceTest.php
+++ b/tests/Unit/Services/SchemaOrgServiceTest.php
@@ -120,6 +120,72 @@ class SchemaOrgServiceTest extends TestCase
         $this->assertEquals('Array Type Widget', SchemaOrgService::parseSchemaOrg(collect($jsonLd), 'title'));
     }
 
+    private function microdataHtml(): string
+    {
+        return <<<'HTML'
+<div itemscope itemtype="https://schema.org/Product">
+  <h1 itemprop="name">Premium Leather Boots</h1>
+  <img itemprop="image" src="https://example.com/boots.jpg" alt="Boots" />
+  <p itemprop="description">Durable and stylish waterproof boots.</p>
+  <div itemprop="offers" itemscope itemtype="https://schema.org/Offer">
+    <span itemprop="priceCurrency" content="USD">$</span>
+    <span itemprop="price" content="149.99">149.99</span>
+    <link itemprop="availability" href="https://schema.org/InStock" />In Stock
+  </div>
+</div>
+HTML;
+    }
+
+    public function test_parse_microdata_extracts_all_fields(): void
+    {
+        $html = $this->microdataHtml();
+
+        $this->assertSame('Premium Leather Boots', SchemaOrgService::parseMicrodata($html, 'title'));
+        $this->assertSame('Durable and stylish waterproof boots.', SchemaOrgService::parseMicrodata($html, 'description'));
+        $this->assertSame('149.99', SchemaOrgService::parseMicrodata($html, 'price'));
+        // content="USD" wins over the visible "$" text.
+        $this->assertSame('USD', SchemaOrgService::parseMicrodata($html, 'price_currency'));
+        // <img> -> src.
+        $this->assertSame('https://example.com/boots.jpg', SchemaOrgService::parseMicrodata($html, 'image'));
+        // <link> -> href (a full schema.org URL StockStatus can map).
+        $this->assertSame('https://schema.org/InStock', SchemaOrgService::parseMicrodata($html, 'availability'));
+    }
+
+    public function test_parse_microdata_returns_null_without_product_itemscope(): void
+    {
+        $html = '<div itemscope itemtype="https://schema.org/Article"><span itemprop="name">Not a product</span></div>';
+
+        $this->assertNull(SchemaOrgService::parseMicrodata($html, 'title'));
+    }
+
+    public function test_parse_microdata_returns_null_when_field_missing(): void
+    {
+        $html = '<div itemscope itemtype="https://schema.org/Product"><span itemprop="name">Widget</span></div>';
+
+        $this->assertSame('Widget', SchemaOrgService::parseMicrodata($html, 'title'));
+        $this->assertNull(SchemaOrgService::parseMicrodata($html, 'price'));
+    }
+
+    public function test_parse_microdata_returns_null_for_blank_html_or_unknown_field(): void
+    {
+        $this->assertNull(SchemaOrgService::parseMicrodata(null, 'title'));
+        $this->assertNull(SchemaOrgService::parseMicrodata('', 'title'));
+        $this->assertNull(SchemaOrgService::parseMicrodata(
+            '<div itemscope itemtype="https://schema.org/Product"><span itemprop="name">X</span></div>',
+            'unknown_field',
+        ));
+    }
+
+    public function test_parse_microdata_does_not_throw_on_malformed_html(): void
+    {
+        $html = '<div itemscope itemtype="https://schema.org/Product"><span itemprop="name">Broken';
+
+        // Must not throw; the libxml parser usually recovers the value, but null is also acceptable.
+        $value = SchemaOrgService::parseMicrodata($html, 'title');
+
+        $this->assertTrue($value === null || $value === 'Broken');
+    }
+
     public function test_parse_schema_org_handles_availability_formats()
     {
         // Simple string availability

--- a/tests/Unit/Services/StrategyExtractorTest.php
+++ b/tests/Unit/Services/StrategyExtractorTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Unit\Services;
 
+use App\Dto\StandardStrategyDto;
+use App\Enums\ScraperStrategyType;
 use App\Services\StrategyExtractor;
 use Jez500\WebScraperForLaravel\WebScraperFake;
 use PHPUnit\Framework\TestCase;
@@ -17,7 +19,7 @@ class StrategyExtractorTest extends TestCase
     {
         $scraper = $this->scraper('<html><body><span id="p">$12.99</span></body></html>');
 
-        $value = StrategyExtractor::extract($scraper, ['type' => 'selector', 'value' => '#p'], 'price');
+        $value = StrategyExtractor::extract($scraper, StandardStrategyDto::fromArray(['type' => 'selector', 'value' => '#p']), 'price');
 
         $this->assertSame('$12.99', $value);
     }
@@ -26,7 +28,7 @@ class StrategyExtractorTest extends TestCase
     {
         $scraper = $this->scraper('<html><head><meta property="og:title" content="Widget"></head></html>');
 
-        $value = StrategyExtractor::extract($scraper, ['type' => 'selector', 'value' => 'meta[property=og:title]|content'], 'title');
+        $value = StrategyExtractor::extract($scraper, StandardStrategyDto::fromArray(['type' => 'selector', 'value' => 'meta[property=og:title]|content']), 'title');
 
         $this->assertSame('Widget', $value);
     }
@@ -35,7 +37,7 @@ class StrategyExtractorTest extends TestCase
     {
         $scraper = $this->scraper('<html><body><script>{"price": 42.50}</script></body></html>');
 
-        $value = StrategyExtractor::extract($scraper, ['type' => 'regex', 'value' => '"price":\s*([0-9.]+)'], 'price');
+        $value = StrategyExtractor::extract($scraper, StandardStrategyDto::fromArray(['type' => 'regex', 'value' => '"price":\s*([0-9.]+)']), 'price');
 
         $this->assertSame('42.50', $value);
     }
@@ -44,23 +46,25 @@ class StrategyExtractorTest extends TestCase
     {
         $scraper = $this->scraper('<html><body><span id="p">10</span></body></html>');
 
-        $value = StrategyExtractor::extract($scraper, ['type' => 'selector', 'value' => '#p', 'prepend' => '$', 'append' => '0'], 'price');
+        $value = StrategyExtractor::extract($scraper, StandardStrategyDto::fromArray(['type' => 'selector', 'value' => '#p', 'prepend' => '$', 'append' => '0']), 'price');
 
         $this->assertSame('$100', $value);
     }
 
-    public function test_returns_null_for_blank_type(): void
+    public function test_returns_null_when_value_missing_for_non_schema_org(): void
     {
         $scraper = $this->scraper('<html></html>');
 
-        $this->assertNull(StrategyExtractor::extract($scraper, ['type' => '', 'value' => 'x'], 'price'));
+        $value = StrategyExtractor::extract($scraper, new StandardStrategyDto(ScraperStrategyType::Selector, null), 'price');
+
+        $this->assertNull($value);
     }
 
     public function test_returns_null_when_selector_matches_nothing_even_with_prepend(): void
     {
         $scraper = $this->scraper('<html><body></body></html>');
 
-        $value = StrategyExtractor::extract($scraper, ['type' => 'selector', 'value' => '#missing', 'prepend' => 'https://example.com', 'append' => '/x'], 'url');
+        $value = StrategyExtractor::extract($scraper, StandardStrategyDto::fromArray(['type' => 'selector', 'value' => '#missing', 'prepend' => 'https://example.com', 'append' => '/x']), 'url');
 
         $this->assertNull($value);
     }
@@ -69,7 +73,7 @@ class StrategyExtractorTest extends TestCase
     {
         $scraper = $this->scraper('<html><body><span id="p">42</span></body></html>');
 
-        $value = StrategyExtractor::extract($scraper, ['type' => 'selector', 'value' => '#p', 'prepend' => '$', 'append' => '.00'], 'price');
+        $value = StrategyExtractor::extract($scraper, StandardStrategyDto::fromArray(['type' => 'selector', 'value' => '#p', 'prepend' => '$', 'append' => '.00']), 'price');
 
         $this->assertSame('$42.00', $value);
     }

--- a/tests/Unit/Services/StrategyExtractorTest.php
+++ b/tests/Unit/Services/StrategyExtractorTest.php
@@ -77,4 +77,20 @@ class StrategyExtractorTest extends TestCase
 
         $this->assertSame('$42.00', $value);
     }
+
+    public function test_schema_org_strategy_falls_back_to_microdata(): void
+    {
+        $html = '<html><body><div itemscope itemtype="https://schema.org/Product">'
+            .'<h1 itemprop="name">Microdata Widget</h1>'
+            .'<div itemprop="offers" itemscope itemtype="https://schema.org/Offer">'
+            .'<span itemprop="price" content="29.95">29.95</span>'
+            .'</div></div></body></html>';
+        $scraper = $this->scraper($html);
+
+        $title = StrategyExtractor::extract($scraper, StandardStrategyDto::fromArray(['type' => 'schema_org', 'value' => null]), 'title');
+        $price = StrategyExtractor::extract($scraper, StandardStrategyDto::fromArray(['type' => 'schema_org', 'value' => null]), 'price');
+
+        $this->assertSame('Microdata Widget', $title);
+        $this->assertSame('29.95', $price);
+    }
 }

--- a/tests/Unit/Services/StrategyExtractorTest.php
+++ b/tests/Unit/Services/StrategyExtractorTest.php
@@ -78,6 +78,20 @@ class StrategyExtractorTest extends TestCase
         $this->assertSame('$42.00', $value);
     }
 
+    public function test_json_ld_takes_precedence_over_microdata_for_the_same_field(): void
+    {
+        $html = '<html><head>'
+            .'<script type="application/ld+json">{"@type":"Product","name":"JSON-LD Name"}</script>'
+            .'</head><body><div itemscope itemtype="https://schema.org/Product">'
+            .'<h1 itemprop="name">Microdata Name</h1>'
+            .'</div></body></html>';
+        $scraper = $this->scraper($html);
+
+        $title = StrategyExtractor::extract($scraper, StandardStrategyDto::fromArray(['type' => 'schema_org', 'value' => null]), 'title');
+
+        $this->assertSame('JSON-LD Name', $title);
+    }
+
     public function test_schema_org_strategy_falls_back_to_microdata(): void
     {
         $html = '<html><body><div itemscope itemtype="https://schema.org/Product">'


### PR DESCRIPTION
## Summary

Adds a stateless `POST /api/meta-extraction` endpoint (sanctum-auth) that extracts `title`/`price`/`image` from a product URL **without persisting anything**. It auto-matches a store config by URL domain and accepts an optional `store` override so callers can preview a custom scrape strategy before saving it.

This was ported from the older `dev` branch (PRIA-77), which had diverged from `main` since early April. Rather than cherry-pick — which would have dragged in dev's competing scraper refactor — the service is **reimplemented against main's current APIs**:

- Uses main's existing `Store::query()->domainFilter()` scope instead of dev's `findByDomain()` helper chain
- Relies only on APIs already present on `main` (`ScrapeUrl` fluent setters, `AutoCreateStore::strategyParse()`, `CurrencyHelper::toFloat`)
- Stays fully decoupled from the `ScrapeSchemaCompiler`/DTO rework on `dev`

## What's included

- `MetaExtractionController` (invokable), `MetaExtractionRequest`, `MetaExtractionResource`, `MetaExtractionService`
- Route + Scramble API docs group
- Docs section in `docs/docs/api.md`
- Feature + unit tests

## Testing

- TDD: tests ported first and watched fail, then implemented to green
- Pint clean, phpcs PASS, PHPStan `[OK] No errors`
- Full suite: **738 passed, 1 skipped, 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `POST /api/meta-extraction` for extracting product metadata (title, price, image, description, availability) using domain-based store resolution with optional inline store overrides and scraper strategies.
  * Added strict public HTTP(S) URL validation to reject internal and non-resolvable targets.
* **Documentation**
  * Added API documentation, including request/response examples for meta extraction.
* **Bug Fixes**
  * Improved Schema.org extraction by adding resilient microdata fallback and stricter image handling.
* **Tests**
  * Added/expanded feature and unit tests covering extraction paths, validation, casting/DTO behavior, and URL-rule enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->