### PR TITLE
Dashboard customization, product create form, and in-place URL editing

### DIFF
--- a/app/Dto/PriceCacheDto.php
+++ b/app/Dto/PriceCacheDto.php
@@ -260,7 +260,7 @@ class PriceCacheDto
             $data['url_id'] ?? null,
             $data['url'] ?? null,
             $data['trend'] ?? Trend::None->value,
-            $data['history'],
+            $data['history'] ?? [],
             $data['last_scrape'] ?? null,
             $data['locale'] ?? null,
             $data['currency'] ?? null,

--- a/app/Filament/Pages/HomeDashboard.php
+++ b/app/Filament/Pages/HomeDashboard.php
@@ -4,7 +4,10 @@ namespace App\Filament\Pages;
 
 use App\Filament\Resources\ProductResource\Actions\CreateAction;
 use App\Filament\Widgets\ProductStats;
+use App\Services\Dashboard\DashboardLayoutService;
+use Filament\Actions\Action;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\Toggle;
 use Filament\Pages\Page;
 use Filament\Support\Facades\FilamentIcon;
 use Filament\Widgets\Widget;
@@ -14,6 +17,18 @@ use Illuminate\Contracts\Support\Htmlable;
 class HomeDashboard extends Page
 {
     protected static string $routePath = '/';
+
+    /**
+     * Human labels for the toggleable dashboard sections.
+     *
+     * @var array<string, string>
+     */
+    private const SECTION_LABELS = [
+        'stat_bar' => 'Summary stats',
+        'buy_now' => "What's good to buy now",
+        'recently_dropped' => 'Recently dropped',
+        'needs_attention' => 'Needs attention',
+    ];
 
     protected static ?int $navigationSort = -2;
 
@@ -76,6 +91,48 @@ class HomeDashboard extends Page
     {
         return [
             CreateAction::make(),
+            $this->customizeAction(),
         ];
+    }
+
+    protected function customizeAction(): Action
+    {
+        return Action::make('customize')
+            ->label(__('Customize'))
+            ->icon('heroicon-o-adjustments-horizontal')
+            ->color('gray')
+            ->modalHeading(__('Customize dashboard'))
+            ->modalSubmitActionLabel(__('Save'))
+            ->fillForm(fn (): array => $this->currentSectionVisibility())
+            ->form(
+                array_map(
+                    fn (string $key): Toggle => Toggle::make($key)->label(__(self::SECTION_LABELS[$key])),
+                    DashboardLayoutService::SECTION_KEYS,
+                )
+            )
+            ->action(function (array $data): void {
+                $layout = new DashboardLayoutService(auth()->user());
+
+                foreach (DashboardLayoutService::SECTION_KEYS as $key) {
+                    $layout->setSectionVisible($key, (bool) ($data[$key] ?? false));
+                }
+
+                $this->dispatch('dashboard-sections-updated');
+            });
+    }
+
+    /**
+     * @return array<string, bool>
+     */
+    protected function currentSectionVisibility(): array
+    {
+        $layout = new DashboardLayoutService(auth()->user());
+
+        $visibility = [];
+        foreach (DashboardLayoutService::SECTION_KEYS as $key) {
+            $visibility[$key] = $layout->isSectionVisible($key);
+        }
+
+        return $visibility;
     }
 }

--- a/app/Filament/Resources/ProductResource.php
+++ b/app/Filament/Resources/ProductResource.php
@@ -11,7 +11,7 @@ use App\Filament\Resources\ProductResource\Api\Transformers\ProductTransformer;
 use App\Filament\Resources\ProductResource\Columns\ProductCardColumn;
 use App\Filament\Resources\ProductResource\Pages;
 use App\Models\Product;
-use App\Models\Tag; // ADD THIS - Missing Tag import
+use App\Models\Tag;
 use App\Providers\Filament\AdminPanelProvider;
 use App\Rules\StoreUrl;
 use App\Services\Helpers\CurrencyHelper;
@@ -81,6 +81,12 @@ class ProductResource extends Resource
     {
         $components = [];
 
+        $components[] = TextInput::make('url')
+            ->label('Product URL')
+            ->hintIcon(Icons::Help->value, 'The domain of the URL must be in the list of available stores')
+            ->rules([new StoreUrl])
+            ->columnSpanFull();
+
         if (is_null($productId)) {
             $components[] = Select::make('product_id')
                 ->label('Existing product')
@@ -93,10 +99,7 @@ class ProductResource extends Resource
                 ->nullable();
         }
 
-        $components[] = TextInput::make('url')
-            ->label('Product URL')
-            ->hintIcon(Icons::Help->value, 'The domain of the URL must be in the list of available stores')
-            ->rules([new StoreUrl]);
+        $components[] = self::createTagsSelect();
 
         $components[] = TextInput::make('price_factor')
             ->label(__('Price Factor'))
@@ -112,8 +115,52 @@ class ProductResource extends Resource
 
         return [
             Forms\Components\Section::make(__('Url of the product'))->schema($components)
+                ->columns(2)
                 ->description(__('Given the url we will scrape the product information. Products and their urls are unique to your user account')),
         ];
+    }
+
+    /**
+     * Tags multi-select for the create form. Unlike the edit form it does not use
+     * `->relationship()` because CreateProduct::handleRecordCreation() persists tags
+     * manually (merging onto existing products); the field just collects tag IDs.
+     */
+    protected static function createTagsSelect(): Select
+    {
+        return Select::make('tags')
+            ->label('Tags')
+            ->multiple()
+            ->options(fn (): array => Tag::where('user_id', auth()->id())
+                ->orderBy('name')
+                ->pluck('name', 'id')
+                ->toArray()
+            )
+            ->searchable()
+            ->preload()
+            ->native(false)
+            ->createOptionForm([
+                TextInput::make('name')
+                    ->label('Tag name')
+                    ->required()
+                    ->maxLength(255)
+                    ->unique(
+                        Tag::class,
+                        'name',
+                        modifyRuleUsing: fn ($rule) => $rule->where('user_id', auth()->id())
+                    ),
+
+                TextInput::make('weight')
+                    ->label('Sort weight')
+                    ->numeric()
+                    ->default(0)
+                    ->helperText(TagResource::getWeightHelperText()),
+
+                Hidden::make('user_id')
+                    ->default(auth()->id()),
+            ])
+            ->createOptionUsing(fn (array $data) => Tag::create($data)->id)
+            ->placeholder('Search tags or create new...')
+            ->noSearchResultsMessage('No tags found');
     }
 
     public static function editForm(Form $form): array

--- a/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
+++ b/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources\ProductResource\Pages;
 
 use App\Filament\Resources\ProductResource;
+use App\Models\Tag;
 use App\Models\Url;
 use Filament\Resources\Pages\CreateRecord;
 use Illuminate\Database\Eloquent\Model;
@@ -36,7 +37,13 @@ class CreateProduct extends CreateRecord
 
         $product = $urlModel->product;
 
-        $tagIds = array_filter((array) data_get($data, 'tags', []));
+        // Scope submitted tag IDs to the current user's own tags: the select only
+        // offers the user's tags, but a tampered request could submit arbitrary IDs.
+        $tagIds = Tag::query()
+            ->where('user_id', auth()->id())
+            ->whereIn('id', (array) data_get($data, 'tags', []))
+            ->pluck('id')
+            ->all();
 
         if ($tagIds !== []) {
             $product->tags()->syncWithoutDetaching($tagIds);

--- a/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
+++ b/app/Filament/Resources/ProductResource/Pages/CreateProduct.php
@@ -34,7 +34,15 @@ class CreateProduct extends CreateRecord
             ]);
         }
 
-        return $urlModel->product;
+        $product = $urlModel->product;
+
+        $tagIds = array_filter((array) data_get($data, 'tags', []));
+
+        if ($tagIds !== []) {
+            $product->tags()->syncWithoutDetaching($tagIds);
+        }
+
+        return $product;
     }
 
     public function getFooterWidgetsColumns(): int|array

--- a/app/Filament/Resources/ProductResource/Widgets/ProductUrlStats.php
+++ b/app/Filament/Resources/ProductResource/Widgets/ProductUrlStats.php
@@ -5,18 +5,17 @@ namespace App\Filament\Resources\ProductResource\Widgets;
 use App\Dto\PriceCacheDto;
 use App\Models\Product;
 use App\Models\Url;
+use App\Rules\StoreUrl;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
-use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\HtmlString;
 
 class ProductUrlStats extends BaseWidget implements HasActions, HasForms
 {
@@ -119,11 +118,10 @@ class ProductUrlStats extends BaseWidget implements HasActions, HasForms
                 ];
             })
             ->form([
-                Placeholder::make('url')
+                TextInput::make('url')
                     ->label('URL')
-                    ->content(fn ($get) => new HtmlString(
-                        '<span style="cursor:pointer" x-on:click="const range = document.createRange(); range.selectNodeContents($el); const sel = window.getSelection(); sel.removeAllRanges(); sel.addRange(range)">'.e($get('url')).'</span>'
-                    )),
+                    ->required()
+                    ->rules([new StoreUrl]),
                 TextInput::make('price_factor')
                     ->label('Price Factor')
                     ->numeric()
@@ -133,12 +131,22 @@ class ProductUrlStats extends BaseWidget implements HasActions, HasForms
             ])
             ->action(function ($arguments, $data) {
                 $url = Url::find($arguments['url']);
+
+                if (trim($data['url']) !== $url->url && ! $url->changeUrl($data['url'])) {
+                    Notification::make('url_update_failed')
+                        ->title('Unable to resolve a store or price for this URL')
+                        ->danger()
+                        ->send();
+
+                    return;
+                }
+
                 $url->update(['price_factor' => $data['price_factor']]);
                 $url->syncStoredPricesForCurrentFactor();
                 $url->product->updatePriceCache();
 
-                Notification::make('price_factor_updated')
-                    ->title('Price factor updated')
+                Notification::make('url_updated')
+                    ->title('URL updated')
                     ->success()
                     ->send();
 

--- a/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
+++ b/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
@@ -63,14 +63,16 @@ class UrlsTableWidget extends BaseWidget
                             ->required(),
                     ])
                     ->using(function (Url $record, array $data): Url {
-                        $record->price_factor = (float) $data['price_factor'];
-                        $record->save();
-
+                        // Validate/apply the URL change first so a failed change leaves
+                        // nothing persisted (changeUrl fails closed) before price_factor.
                         if (trim($data['url']) !== $record->url && ! $record->changeUrl($data['url'])) {
                             throw ValidationException::withMessages([
                                 'url' => __('Unable to resolve a store or price for this URL'),
                             ]);
                         }
+
+                        $record->price_factor = (float) $data['price_factor'];
+                        $record->save();
 
                         return $record;
                     })

--- a/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
+++ b/app/Filament/Resources/ProductResource/Widgets/UrlsTableWidget.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources\ProductResource\Widgets;
 
 use App\Models\Product;
 use App\Models\Url;
+use App\Rules\StoreUrl;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Tables;
@@ -12,6 +13,7 @@ use Filament\Widgets\TableWidget as BaseWidget;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\HtmlString;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 
 class UrlsTableWidget extends BaseWidget
 {
@@ -51,7 +53,8 @@ class UrlsTableWidget extends BaseWidget
                     ->form([
                         TextInput::make('url')
                             ->label('URL')
-                            ->disabled(),
+                            ->required()
+                            ->rules([new StoreUrl]),
                         TextInput::make('price_factor')
                             ->label('Price Factor')
                             ->numeric()
@@ -59,12 +62,24 @@ class UrlsTableWidget extends BaseWidget
                             ->minValue(0.01)
                             ->required(),
                     ])
+                    ->using(function (Url $record, array $data): Url {
+                        $record->price_factor = (float) $data['price_factor'];
+                        $record->save();
+
+                        if (trim($data['url']) !== $record->url && ! $record->changeUrl($data['url'])) {
+                            throw ValidationException::withMessages([
+                                'url' => __('Unable to resolve a store or price for this URL'),
+                            ]);
+                        }
+
+                        return $record;
+                    })
                     ->after(function (Url $record) {
                         $record->syncStoredPricesForCurrentFactor();
                         $record->product->updatePriceCache();
 
-                        Notification::make('price_factor_updated')
-                            ->title('Price factor updated')
+                        Notification::make('url_updated')
+                            ->title('URL updated')
                             ->success()
                             ->send();
                     }),

--- a/app/Filament/Widgets/ProductStats.php
+++ b/app/Filament/Widgets/ProductStats.php
@@ -3,10 +3,12 @@
 namespace App\Filament\Widgets;
 
 use App\Models\Product;
+use App\Models\Tag;
 use App\Services\Dashboard\DashboardLayoutService;
 use App\Services\Dashboard\DashboardSections;
 use Filament\Widgets\Widget;
 use Illuminate\Database\Eloquent\Collection;
+use Livewire\Attributes\On;
 
 class ProductStats extends Widget
 {
@@ -130,10 +132,54 @@ class ProductStats extends Widget
         (new DashboardLayoutService(auth()->user()))->setCategoryOrder($orderedSignatures);
     }
 
-    public function toggleSection(string $key): void
+    /**
+     * Move a product into another category by replacing its tags with the
+     * destination group's tag-set, then persist the destination ordering.
+     *
+     * @param  array<int, int|string>  $orderedIds
+     */
+    public function moveProductToCategory(int $productId, string $targetSignature, array $orderedIds): void
     {
-        (new DashboardLayoutService(auth()->user()))->toggleSection($key);
+        $product = Product::query()
+            ->where('user_id', auth()->id())
+            ->find($productId);
+
+        if (! $product instanceof Product) {
+            return;
+        }
+
+        $product->tags()->sync($this->tagIdsForSignature($targetSignature));
+
+        $this->reorderProducts($orderedIds);
     }
+
+    /**
+     * Resolve a category signature (sorted tag IDs joined by '-', or the
+     * 'uncategorized' sentinel) to the current user's matching tag IDs.
+     *
+     * @return array<int, int>
+     */
+    private function tagIdsForSignature(string $signature): array
+    {
+        if ($signature === 'uncategorized' || $signature === '') {
+            return [];
+        }
+
+        $ids = array_map('intval', explode('-', $signature));
+
+        return Tag::query()
+            ->where('user_id', auth()->id())
+            ->whereIn('id', $ids)
+            ->pluck('id')
+            ->map(fn ($id): int => (int) $id)
+            ->all();
+    }
+
+    /**
+     * Re-render when the page's Customize modal changes section visibility.
+     */
+    #[On('dashboard-sections-updated')]
+    public function refreshSections(): void {}
 
     public function toggleCategoryCollapse(string $signature): void
     {

--- a/app/Filament/Widgets/ProductStats.php
+++ b/app/Filament/Widgets/ProductStats.php
@@ -57,8 +57,47 @@ class ProductStats extends Widget
 
     public function getViewData(): array
     {
+        $user = auth()->user();
+        $layout = new \App\Services\Dashboard\DashboardLayoutService($user);
+        $sectionsService = new \App\Services\Dashboard\DashboardSections($user);
+
+        $groups = $this->orderGroups(self::getProductsGrouped(), $layout);
+
         return [
-            'groups' => self::getCachedProducts(),
+            'groups' => $groups,
+            'sections' => $layout->sections(),
+            'sectionData' => [
+                'stat_bar' => $sectionsService->statBar(),
+                'buy_now' => $sectionsService->buyNow(),
+                'recently_dropped' => $sectionsService->recentlyDropped(),
+                'needs_attention' => $sectionsService->needsAttention(),
+            ],
         ];
+    }
+
+    /**
+     * @param  array<int|string, array<string, mixed>>  $groups
+     * @return array<int, array<string, mixed>>
+     */
+    private function orderGroups(array $groups, \App\Services\Dashboard\DashboardLayoutService $layout): array
+    {
+        $order = $layout->categoryOrder();
+
+        $groups = collect($groups)->map(function (array $group) use ($layout): array {
+            $group['collapsed'] = $layout->isCategoryCollapsed($group['signature']);
+
+            return $group;
+        });
+
+        if ($order === []) {
+            return $groups->values()->all(); // already weight-sorted by getProductsGrouped()
+        }
+
+        $rank = array_flip($order); // signature => index
+
+        return $groups
+            ->sortBy(fn (array $group): int => $rank[$group['signature']] ?? PHP_INT_MAX)
+            ->values()
+            ->all();
     }
 }

--- a/app/Filament/Widgets/ProductStats.php
+++ b/app/Filament/Widgets/ProductStats.php
@@ -8,6 +8,7 @@ use App\Services\Dashboard\DashboardLayoutService;
 use App\Services\Dashboard\DashboardSections;
 use Filament\Widgets\Widget;
 use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
 use Livewire\Attributes\On;
 
 class ProductStats extends Widget
@@ -29,12 +30,9 @@ class ProductStats extends Widget
             ->orderByDesc('created_at')
             ->get()
             ->filter(fn (Product $product) => isset($product->price_cache[0]))
-            ->groupBy(fn (Product $product) => $product->tags->count() > 0
-                ? $product->tags->pluck('name')->implode(', ')
-                : 'Uncategorized'
-            )
-            ->map(fn (Collection $products, string $tagName) => [
-                'heading' => $tagName,
+            ->groupBy(fn (Product $product): string => self::categorySignature($product->tags))
+            ->map(fn (Collection $products): array => [
+                'heading' => self::categoryHeading($products->first()->tags),
                 'signature' => self::categorySignature($products->first()->tags),
                 'products' => $products,
                 'weight' => $products->first()->tags->count() > 0
@@ -50,6 +48,18 @@ class ProductStats extends Widget
         return $tags->isEmpty()
             ? 'uncategorized'
             : $tags->pluck('id')->sort()->values()->implode('-');
+    }
+
+    /**
+     * Deterministic display heading for a tag-set, so the same combination of
+     * tags always produces one group with a stable label regardless of the
+     * order tags were attached in.
+     */
+    public static function categoryHeading(\Illuminate\Support\Collection $tags): string
+    {
+        return $tags->isEmpty()
+            ? 'Uncategorized'
+            : $tags->sortBy('name')->pluck('name')->implode(', ');
     }
 
     public function getViewData(): array
@@ -111,17 +121,19 @@ class ProductStats extends Widget
 
         $ownedIds = array_map('intval', $owned);
 
-        $weight = 0;
-        foreach ($orderedIds as $id) {
-            if (! in_array((int) $id, $ownedIds, true)) {
-                continue;
+        DB::transaction(function () use ($orderedIds, $ownedIds): void {
+            $weight = 0;
+            foreach ($orderedIds as $id) {
+                if (! in_array((int) $id, $ownedIds, true)) {
+                    continue;
+                }
+                Product::query()
+                    ->where('user_id', auth()->id())
+                    ->where('id', $id)
+                    ->update(['weight' => $weight]);
+                $weight++;
             }
-            Product::query()
-                ->where('user_id', auth()->id())
-                ->where('id', $id)
-                ->update(['weight' => $weight]);
-            $weight++;
-        }
+        });
     }
 
     /**

--- a/app/Filament/Widgets/ProductStats.php
+++ b/app/Filament/Widgets/ProductStats.php
@@ -38,6 +38,7 @@ class ProductStats extends Widget
             )
             ->map(fn (Collection $products, string $tagName) => [
                 'heading' => $tagName,
+                'signature' => self::categorySignature($products->first()->tags),
                 'products' => $products,
                 'weight' => $products->first()->tags->count() > 0
                     ? $products->first()->tags->max('weight')
@@ -45,6 +46,13 @@ class ProductStats extends Widget
             ])
             ->sortBy('weight')
             ->toArray();
+    }
+
+    public static function categorySignature(\Illuminate\Support\Collection $tags): string
+    {
+        return $tags->isEmpty()
+            ? 'uncategorized'
+            : $tags->pluck('id')->sort()->values()->implode('-');
     }
 
     public function getViewData(): array

--- a/app/Filament/Widgets/ProductStats.php
+++ b/app/Filament/Widgets/ProductStats.php
@@ -3,6 +3,8 @@
 namespace App\Filament\Widgets;
 
 use App\Models\Product;
+use App\Services\Dashboard\DashboardLayoutService;
+use App\Services\Dashboard\DashboardSections;
 use Filament\Widgets\Widget;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -12,14 +14,7 @@ class ProductStats extends Widget
 
     protected static bool $isLazy = false;
 
-    protected static ?array $cachedProducts = null;
-
     protected static string $view = 'filament.widgets.product-stats-grouped';
-
-    protected static function getCachedProducts(): array
-    {
-        return self::$cachedProducts ??= self::getProductsGrouped();
-    }
 
     public static function getProductsGrouped(): array
     {
@@ -58,8 +53,8 @@ class ProductStats extends Widget
     public function getViewData(): array
     {
         $user = auth()->user();
-        $layout = new \App\Services\Dashboard\DashboardLayoutService($user);
-        $sectionsService = new \App\Services\Dashboard\DashboardSections($user);
+        $layout = new DashboardLayoutService($user);
+        $sectionsService = new DashboardSections($user);
 
         $groups = $this->orderGroups(self::getProductsGrouped(), $layout);
 
@@ -79,7 +74,7 @@ class ProductStats extends Widget
      * @param  array<int|string, array<string, mixed>>  $groups
      * @return array<int, array<string, mixed>>
      */
-    private function orderGroups(array $groups, \App\Services\Dashboard\DashboardLayoutService $layout): array
+    private function orderGroups(array $groups, DashboardLayoutService $layout): array
     {
         $order = $layout->categoryOrder();
 
@@ -99,5 +94,49 @@ class ProductStats extends Widget
             ->sortBy(fn (array $group): int => $rank[$group['signature']] ?? PHP_INT_MAX)
             ->values()
             ->all();
+    }
+
+    /**
+     * @param  array<int, int|string>  $orderedIds
+     */
+    public function reorderProducts(array $orderedIds): void
+    {
+        $owned = Product::query()
+            ->where('user_id', auth()->id())
+            ->whereIn('id', $orderedIds)
+            ->pluck('id')
+            ->all();
+
+        $ownedIds = array_map('intval', $owned);
+
+        $weight = 0;
+        foreach ($orderedIds as $id) {
+            if (! in_array((int) $id, $ownedIds, true)) {
+                continue;
+            }
+            Product::query()
+                ->where('user_id', auth()->id())
+                ->where('id', $id)
+                ->update(['weight' => $weight]);
+            $weight++;
+        }
+    }
+
+    /**
+     * @param  array<int, string>  $orderedSignatures
+     */
+    public function reorderCategories(array $orderedSignatures): void
+    {
+        (new DashboardLayoutService(auth()->user()))->setCategoryOrder($orderedSignatures);
+    }
+
+    public function toggleSection(string $key): void
+    {
+        (new DashboardLayoutService(auth()->user()))->toggleSection($key);
+    }
+
+    public function toggleCategoryCollapse(string $signature): void
+    {
+        (new DashboardLayoutService(auth()->user()))->toggleCategoryCollapse($signature);
     }
 }

--- a/app/Livewire/ProductCardDetail.php
+++ b/app/Livewire/ProductCardDetail.php
@@ -25,16 +25,19 @@ class ProductCardDetail extends Component implements HasActions, HasForms
 
     public bool $showChart = false;
 
+    public bool $showNextCheck = true;
+
     public function getRecord(): Product
     {
         return $this->product;
     }
 
-    public function mount(Product $product, bool $standalone = false, bool $showChart = false): void
+    public function mount(Product $product, bool $standalone = false, bool $showChart = false, bool $showNextCheck = true): void
     {
         $this->product = $product;
         $this->standalone = $standalone;
         $this->showChart = $showChart;
+        $this->showNextCheck = $showNextCheck;
     }
 
     public function addUrlAction(): Action

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -187,12 +187,14 @@ class Product extends Model
             return __('due');
         }
 
-        if ($seconds >= 86400) {
-            return ((int) round($seconds / 86400)).'d';
-        }
-
         if ($seconds >= 3600) {
-            return ((int) round($seconds / 3600)).'h';
+            $hours = (int) round($seconds / 3600);
+
+            // Once the rounded hours reach a full day, show days so we never
+            // render "24h" instead of "1d".
+            return $hours >= 24
+                ? ((int) round($seconds / 86400)).'d'
+                : $hours.'h';
         }
 
         return '<1h';

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -170,6 +170,35 @@ class Product extends Model
     }
 
     /**
+     * Coarse, rounded label for the upcoming check, e.g. "1h", "2d" or "<1h".
+     * Null when there is no scheduled check (paused / unscheduled).
+     */
+    public function nextCheckShortLabel(): ?string
+    {
+        $next = $this->nextCheckEstimate();
+
+        if (! $next) {
+            return null;
+        }
+
+        $seconds = $next->getTimestamp() - now()->getTimestamp();
+
+        if ($seconds <= 0) {
+            return __('due');
+        }
+
+        if ($seconds >= 86400) {
+            return ((int) round($seconds / 86400)).'d';
+        }
+
+        if ($seconds >= 3600) {
+            return ((int) round($seconds / 3600)).'h';
+        }
+
+        return '<1h';
+    }
+
+    /**
      * Resolve the next/previous run of the global scrape_schedule cron.
      */
     protected function globalScheduleRun(string $direction): ?Carbon

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -174,30 +174,7 @@ class Url extends Model
     {
         $userId = $userId ?? auth()->id();
 
-        if ($createStore) {
-            AutoCreateStore::createStoreFromUrl($url);
-        }
-
-        // Suppress UI toasts on these intermediate scrapes: a first attempt may legitimately
-        // fail (e.g. bot-blocked) before AI self-healing switches to browser scraping. The
-        // only user-facing feedback is the final outcome (product created, or the caller's error).
-        $scrape = ScrapeUrl::new($url)->setSendUiNotifications(false)->scrape();
-
-        /** @var ?Store $store */
-        $store = data_get($scrape, 'store');
-
-        $availabilityStrategy = data_get($store, 'scrape_strategy.availability');
-        $isUnavailable = StockStatus::resolveAvailability(data_get($scrape, 'availability'), $availabilityStrategy)->isUnavailable();
-
-        // AI fallback: when a normal create would fail, let the healing agent build or
-        // repair the store config, then re-scrape once with the new config.
-        if ((! $store || (! data_get($scrape, 'price') && ! $isUnavailable))
-            && AiConfigHealer::new()->healStoreForUrl($url, $store, data_get($scrape, 'body')) !== null) {
-            $scrape = ScrapeUrl::new($url)->setSendUiNotifications(false)->scrape();
-            $store = data_get($scrape, 'store');
-            $availabilityStrategy = data_get($store, 'scrape_strategy.availability');
-            $isUnavailable = StockStatus::resolveAvailability(data_get($scrape, 'availability'), $availabilityStrategy)->isUnavailable();
-        }
+        ['store' => $store, 'scrape' => $scrape, 'isUnavailable' => $isUnavailable] = self::scrapeAndResolveStore($url, $createStore);
 
         if (! $store || (! data_get($scrape, 'price') && ! $isUnavailable)) {
             return false;
@@ -229,6 +206,76 @@ class Url extends Model
         $urlModel->updatePrice(data_get($scrape, 'price'), $scrape);
 
         return $urlModel;
+    }
+
+    /**
+     * Re-point this URL to a new address, keeping the record (and therefore its price
+     * history) intact. The store is re-resolved from the new domain and a fresh price is
+     * scraped and appended. Fails closed: on an invalid/unresolvable URL the record is
+     * left untouched and `false` is returned.
+     */
+    public function changeUrl(string $newUrl, bool $createStore = true): bool
+    {
+        $newUrl = trim($newUrl);
+
+        if ($newUrl === '' || ! filter_var($newUrl, FILTER_VALIDATE_URL)) {
+            return false;
+        }
+
+        if ($newUrl === $this->url) {
+            return true;
+        }
+
+        ['store' => $store, 'scrape' => $scrape, 'isUnavailable' => $isUnavailable] = self::scrapeAndResolveStore($newUrl, $createStore);
+
+        if (! $store || (! data_get($scrape, 'price') && ! $isUnavailable)) {
+            return false;
+        }
+
+        $this->forceFill([
+            'url' => $newUrl,
+            'store_id' => $store->getKey(),
+        ])->save();
+
+        $this->updatePrice(data_get($scrape, 'price'), $scrape);
+
+        return true;
+    }
+
+    /**
+     * Scrape a URL and resolve its Store, using AI self-healing as a fallback when a
+     * normal scrape would not yield a usable store/price.
+     *
+     * @return array{store: ?Store, scrape: array<string, mixed>, isUnavailable: bool}
+     */
+    protected static function scrapeAndResolveStore(string $url, bool $createStore = true): array
+    {
+        if ($createStore) {
+            AutoCreateStore::createStoreFromUrl($url);
+        }
+
+        // Suppress UI toasts on these intermediate scrapes: a first attempt may legitimately
+        // fail (e.g. bot-blocked) before AI self-healing switches to browser scraping. The
+        // only user-facing feedback is the final outcome (product created, or the caller's error).
+        $scrape = ScrapeUrl::new($url)->setSendUiNotifications(false)->scrape();
+
+        /** @var ?Store $store */
+        $store = data_get($scrape, 'store');
+
+        $availabilityStrategy = data_get($store, 'scrape_strategy.availability');
+        $isUnavailable = StockStatus::resolveAvailability(data_get($scrape, 'availability'), $availabilityStrategy)->isUnavailable();
+
+        // AI fallback: when a normal create would fail, let the healing agent build or
+        // repair the store config, then re-scrape once with the new config.
+        if ((! $store || (! data_get($scrape, 'price') && ! $isUnavailable))
+            && AiConfigHealer::new()->healStoreForUrl($url, $store, data_get($scrape, 'body')) !== null) {
+            $scrape = ScrapeUrl::new($url)->setSendUiNotifications(false)->scrape();
+            $store = data_get($scrape, 'store');
+            $availabilityStrategy = data_get($store, 'scrape_strategy.availability');
+            $isUnavailable = StockStatus::resolveAvailability(data_get($scrape, 'availability'), $availabilityStrategy)->isUnavailable();
+        }
+
+        return ['store' => $store, 'scrape' => $scrape, 'isUnavailable' => $isUnavailable];
     }
 
     public function updatePrice(int|float|string|null $price = null, ?array $scrapeResult = null): Price|Model|null

--- a/app/Services/Dashboard/DashboardLayoutService.php
+++ b/app/Services/Dashboard/DashboardLayoutService.php
@@ -8,6 +8,18 @@ class DashboardLayoutService
 {
     public const SECTION_KEYS = ['stat_bar', 'buy_now', 'recently_dropped', 'needs_attention'];
 
+    /**
+     * Default visibility per section for users with no stored preference.
+     *
+     * @var array<string, bool>
+     */
+    private const DEFAULT_VISIBILITY = [
+        'stat_bar' => false,
+        'buy_now' => true,
+        'recently_dropped' => false,
+        'needs_attention' => false,
+    ];
+
     public function __construct(private readonly User $user) {}
 
     /**
@@ -20,14 +32,14 @@ class DashboardLayoutService
         return collect(self::SECTION_KEYS)
             ->map(fn (string $key): array => [
                 'key' => $key,
-                'visible' => (bool) data_get($stored, $key.'.visible', true),
+                'visible' => (bool) data_get($stored, $key.'.visible', $this->defaultVisibility($key)),
             ])
             ->all();
     }
 
     public function isSectionVisible(string $key): bool
     {
-        return (bool) data_get($this->user->settings, "dashboard.sections.$key.visible", true);
+        return (bool) data_get($this->user->settings, "dashboard.sections.$key.visible", $this->defaultVisibility($key));
     }
 
     /**
@@ -49,8 +61,13 @@ class DashboardLayoutService
             return;
         }
 
-        $current = (bool) data_get($this->user->settings, "dashboard.sections.$key.visible", true);
+        $current = (bool) data_get($this->user->settings, "dashboard.sections.$key.visible", $this->defaultVisibility($key));
         $this->write("dashboard.sections.$key.visible", ! $current);
+    }
+
+    private function defaultVisibility(string $key): bool
+    {
+        return self::DEFAULT_VISIBILITY[$key] ?? true;
     }
 
     public function toggleCategoryCollapse(string $signature): void

--- a/app/Services/Dashboard/DashboardLayoutService.php
+++ b/app/Services/Dashboard/DashboardLayoutService.php
@@ -65,6 +65,15 @@ class DashboardLayoutService
         $this->write("dashboard.sections.$key.visible", ! $current);
     }
 
+    public function setSectionVisible(string $key, bool $visible): void
+    {
+        if (! in_array($key, self::SECTION_KEYS, true)) {
+            return;
+        }
+
+        $this->write("dashboard.sections.$key.visible", $visible);
+    }
+
     private function defaultVisibility(string $key): bool
     {
         return self::DEFAULT_VISIBILITY[$key] ?? true;

--- a/app/Services/Dashboard/DashboardLayoutService.php
+++ b/app/Services/Dashboard/DashboardLayoutService.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Services\Dashboard;
+
+use App\Models\User;
+
+class DashboardLayoutService
+{
+    public const SECTION_KEYS = ['stat_bar', 'buy_now', 'recently_dropped', 'needs_attention'];
+
+    public function __construct(private readonly User $user) {}
+
+    /**
+     * @return array<int, array{key: string, visible: bool}>
+     */
+    public function sections(): array
+    {
+        $stored = data_get($this->user->settings, 'dashboard.sections', []);
+
+        $sections = collect(self::SECTION_KEYS)
+            ->map(fn (string $key, int $index): array => [
+                'key' => $key,
+                'visible' => (bool) data_get($stored, $key.'.visible', true),
+                'order' => (int) data_get($stored, $key.'.order', $index),
+            ])
+            ->sortBy('order')
+            ->values();
+
+        return $sections->map(fn (array $s): array => ['key' => $s['key'], 'visible' => $s['visible']])->all();
+    }
+
+    public function isSectionVisible(string $key): bool
+    {
+        return (bool) data_get($this->user->settings, "dashboard.sections.$key.visible", true);
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    public function categoryOrder(): array
+    {
+        return array_values((array) data_get($this->user->settings, 'dashboard.categories.order', []));
+    }
+
+    public function isCategoryCollapsed(string $signature): bool
+    {
+        return in_array($signature, (array) data_get($this->user->settings, 'dashboard.categories.collapsed', []), true);
+    }
+
+    public function toggleSection(string $key): void
+    {
+        if (! in_array($key, self::SECTION_KEYS, true)) {
+            return;
+        }
+
+        $current = (bool) data_get($this->user->settings, "dashboard.sections.$key.visible", true);
+        $this->write("dashboard.sections.$key.visible", ! $current);
+    }
+
+    public function toggleCategoryCollapse(string $signature): void
+    {
+        $collapsed = (array) data_get($this->user->settings, 'dashboard.categories.collapsed', []);
+
+        $collapsed = in_array($signature, $collapsed, true)
+            ? array_values(array_diff($collapsed, [$signature]))
+            : [...$collapsed, $signature];
+
+        $this->write('dashboard.categories.collapsed', $collapsed);
+    }
+
+    /**
+     * @param  array<int, string>  $signatures
+     */
+    public function setCategoryOrder(array $signatures): void
+    {
+        $this->write('dashboard.categories.order', array_values($signatures));
+    }
+
+    private function write(string $path, mixed $value): void
+    {
+        $settings = $this->user->settings ?? [];
+        data_set($settings, $path, $value);
+        $this->user->settings = $settings;
+        $this->user->save();
+    }
+}

--- a/app/Services/Dashboard/DashboardLayoutService.php
+++ b/app/Services/Dashboard/DashboardLayoutService.php
@@ -17,16 +17,12 @@ class DashboardLayoutService
     {
         $stored = data_get($this->user->settings, 'dashboard.sections', []);
 
-        $sections = collect(self::SECTION_KEYS)
-            ->map(fn (string $key, int $index): array => [
+        return collect(self::SECTION_KEYS)
+            ->map(fn (string $key): array => [
                 'key' => $key,
                 'visible' => (bool) data_get($stored, $key.'.visible', true),
-                'order' => (int) data_get($stored, $key.'.order', $index),
             ])
-            ->sortBy('order')
-            ->values();
-
-        return $sections->map(fn (array $s): array => ['key' => $s['key'], 'visible' => $s['visible']])->all();
+            ->all();
     }
 
     public function isSectionVisible(string $key): bool

--- a/app/Services/Dashboard/DashboardSections.php
+++ b/app/Services/Dashboard/DashboardSections.php
@@ -12,22 +12,37 @@ class DashboardSections
 {
     private const BUY_NOW_MIN_SCORE = 6.0;
 
+    /** @var ?Collection<int, Product> */
+    private ?Collection $trackedProducts = null;
+
     public function __construct(private readonly User $user) {}
 
     /**
      * Products belonging to the user that are published and have a usable
      * materialized price cache (matches the widget's `price_cache[0]` guard).
+     * Memoized: repeated calls within one instance reuse the same query.
      *
      * @return Collection<int, Product>
      */
     private function trackedProducts(): Collection
     {
-        return Product::query()
+        return $this->trackedProducts ??= Product::query()
             ->where('user_id', $this->user->id)
             ->published()
             ->get()
-            ->filter(fn (Product $p): bool => $p->current_price > 0 && ! empty($p->price_cache))
+            ->filter(fn (Product $p): bool => $this->isTracked($p))
             ->values();
+    }
+
+    /**
+     * Whether a product has a usable materialized price cache (matches the
+     * widget's `price_cache[0]` guard). Shared by `trackedProducts()` and
+     * `needsAttention()` so the "excluded from all sections" invariant lives
+     * in one place.
+     */
+    private function isTracked(Product $p): bool
+    {
+        return $p->current_price > 0 && ! empty($p->price_cache);
     }
 
     /**
@@ -92,7 +107,7 @@ class DashboardSections
             ->published()
             ->where('paused', false)
             ->get()
-            ->filter(fn (Product $p): bool => $p->current_price > 0 && ! empty($p->price_cache) && ! $p->is_last_scrape_successful)
+            ->filter(fn (Product $p): bool => $this->isTracked($p) && ! $p->is_last_scrape_successful)
             ->values();
     }
 

--- a/app/Services/Dashboard/DashboardSections.php
+++ b/app/Services/Dashboard/DashboardSections.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Services\Dashboard;
+
+use App\Enums\StockStatus;
+use App\Enums\Trend;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Support\Collection;
+
+class DashboardSections
+{
+    private const BUY_NOW_MIN_SCORE = 6.0;
+
+    public function __construct(private readonly User $user) {}
+
+    /**
+     * Products belonging to the user that are published and have a usable
+     * materialized price cache (matches the widget's `price_cache[0]` guard).
+     *
+     * @return Collection<int, Product>
+     */
+    private function trackedProducts(): Collection
+    {
+        return Product::query()
+            ->where('user_id', $this->user->id)
+            ->published()
+            ->get()
+            ->filter(fn (Product $p): bool => $p->current_price > 0 && ! empty($p->price_cache))
+            ->values();
+    }
+
+    /**
+     * @return array{tracked:int, atLowest:int, belowAverage:int, outOfStock:int, potentialSavings:float}
+     */
+    public function statBar(): array
+    {
+        $products = $this->trackedProducts();
+
+        return [
+            'tracked' => $products->count(),
+            'atLowest' => $products->filter(fn (Product $p): bool => $p->trend === Trend::Lowest->value)->count(),
+            'belowAverage' => $products->filter(fn (Product $p): bool => in_array($p->trend, [Trend::Down->value, Trend::Lowest->value], true))->count(),
+            'outOfStock' => $products->filter(fn (Product $p): bool => $this->isOutOfStock($p))->count(),
+            'potentialSavings' => round($products->sum(fn (Product $p): float => max(0, $p->getPriceCacheAggregate('avg') - $p->current_price)), 2),
+        ];
+    }
+
+    /**
+     * @return Collection<int, Product>
+     */
+    public function buyNow(): Collection
+    {
+        return $this->trackedProducts()
+            ->filter(fn (Product $p): bool => (float) data_get($p->insights_cache, 'dealScore.score', 0) >= self::BUY_NOW_MIN_SCORE)
+            ->sortByDesc(fn (Product $p): array => [
+                (bool) data_get($p->insights_cache, 'dealScore.isAllTimeLow', false) ? 1 : 0,
+                (float) data_get($p->insights_cache, 'dealScore.score', 0),
+            ])
+            ->values();
+    }
+
+    /**
+     * @return Collection<int, Product>
+     */
+    public function recentlyDropped(int $days = 7): Collection
+    {
+        $droppedIds = Product::query()
+            ->where('user_id', $this->user->id)
+            ->published()
+            ->lowestPriceInDays($days)
+            ->pluck('id');
+
+        return $this->trackedProducts()
+            ->filter(fn (Product $p): bool => $droppedIds->contains($p->id))
+            ->sortByDesc(fn (Product $p): float => $p->getPriceCacheAggregate('avg') - $p->current_price)
+            ->values();
+    }
+
+    /**
+     * Non-paused, published products with a failed/stale last scrape. The
+     * `favourite` filter is intentionally relaxed here: a non-favourite
+     * product that is failing to scrape must still surface so the user
+     * notices it.
+     *
+     * @return Collection<int, Product>
+     */
+    public function needsAttention(): Collection
+    {
+        return Product::query()
+            ->where('user_id', $this->user->id)
+            ->published()
+            ->where('paused', false)
+            ->get()
+            ->filter(fn (Product $p): bool => $p->current_price > 0 && ! empty($p->price_cache) && ! $p->is_last_scrape_successful)
+            ->values();
+    }
+
+    /**
+     * A product is considered out of stock when any cached price row's
+     * `availability` matches `StockStatus::OutOfStock` (see
+     * `PriceCacheDto::toArray()`, which stores `null` for in-stock rows and
+     * the enum's string value otherwise).
+     */
+    private function isOutOfStock(Product $p): bool
+    {
+        return collect($p->price_cache)
+            ->contains(fn ($row): bool => ($row['availability'] ?? null) === StockStatus::OutOfStock->value);
+    }
+}

--- a/app/Services/Dashboard/DashboardSections.php
+++ b/app/Services/Dashboard/DashboardSections.php
@@ -12,6 +12,12 @@ class DashboardSections
 {
     private const BUY_NOW_MIN_SCORE = 6.0;
 
+    private const BUY_NOW_LIMIT = 6;
+
+    private const RECENTLY_DROPPED_LIMIT = 6;
+
+    private const NEEDS_ATTENTION_LIMIT = 15;
+
     /** @var ?Collection<int, Product> */
     private ?Collection $trackedProducts = null;
 
@@ -72,7 +78,8 @@ class DashboardSections
                 (bool) data_get($p->insights_cache, 'dealScore.isAllTimeLow', false) ? 1 : 0,
                 (float) data_get($p->insights_cache, 'dealScore.score', 0),
             ])
-            ->values();
+            ->values()
+            ->take(self::BUY_NOW_LIMIT);
     }
 
     /**
@@ -89,7 +96,8 @@ class DashboardSections
         return $this->trackedProducts()
             ->filter(fn (Product $p): bool => $droppedIds->contains($p->id))
             ->sortByDesc(fn (Product $p): float => $p->getPriceCacheAggregate('avg') - $p->current_price)
-            ->values();
+            ->values()
+            ->take(self::RECENTLY_DROPPED_LIMIT);
     }
 
     /**
@@ -108,7 +116,8 @@ class DashboardSections
             ->where('paused', false)
             ->get()
             ->filter(fn (Product $p): bool => $this->isTracked($p) && ! $p->is_last_scrape_successful)
-            ->values();
+            ->values()
+            ->take(self::NEEDS_ATTENTION_LIMIT);
     }
 
     /**

--- a/app/View/Components/ProductCard.php
+++ b/app/View/Components/ProductCard.php
@@ -13,7 +13,8 @@ class ProductCard extends Component
      * Create a new component instance.
      */
     public function __construct(
-        public Product $product
+        public Product $product,
+        public bool $draggable = false,
     ) {
         //
     }

--- a/docs/docs/features.md
+++ b/docs/docs/features.md
@@ -71,6 +71,23 @@ in a docker container with a rest api.
 Tag products to better organise them. Tags can be used to filter products on the
 dashboard.
 
+## Customisable dashboard
+
+Arrange the dashboard to suit you. Products are grouped by [tag](/tags.html#tags-on-the-dashboard),
+and you can drag to reorder the groups and the products within them, drag a
+product from one group to another to re-tag it, and collapse groups you don't
+need open.
+
+Use the **Customize** button to show or hide the summary stats and the smart
+sections that sit above your groups:
+
+- **What's good to buy now** — products that are a good buy right now.
+- **Recently dropped** — products whose price has recently fallen.
+- **Needs attention** — tracked products whose latest price check failed.
+
+Your layout, group order, collapse state and section choices are all saved per
+user.
+
 ## Multi-user support
 
 Each user has their own products, tags and settings. Great for sharing with others

--- a/docs/docs/tags.md
+++ b/docs/docs/tags.md
@@ -17,5 +17,30 @@ to filter the products by.
 
 ## Tags on the dashboard
 
-Products will be grouped by tag on the dashboard, if a product does not have a
-tag it will be grouped under `Uncategorized`.
+Products are grouped by tag on the dashboard. A product with no tag is grouped
+under `Uncategorized`. Only your favourite, published products appear here.
+
+The dashboard remembers how you arrange it — the ordering and collapse state
+below are saved per user.
+
+### Reorder tag groups
+
+Drag a group by its heading — the tag icon and name — to move it up or down. The
+order is remembered the next time you visit.
+
+### Collapse groups
+
+Use the chevron on the right of a group heading to collapse or expand that group.
+Collapsed groups stay collapsed until you expand them again.
+
+### Move products between groups
+
+Drag a product by its image to:
+
+- reorder it within its current group, or
+- drop it onto another group to re-tag it. Dropping a product onto a tag group
+  replaces its tags with that group's tag(s); dropping it onto `Uncategorized`
+  removes its tags.
+
+See [Customisable dashboard](/features.html#customisable-dashboard) for the
+summary stats and smart sections that sit above your tag groups.

--- a/resources/views/components/livewire/product-card-detail.blade.php
+++ b/resources/views/components/livewire/product-card-detail.blade.php
@@ -32,7 +32,9 @@
             {{ $this->deleteAction }}
         </div>
 
-        @include('components.price-aggregates', ['aggregates' => $product->price_aggregates, 'trend' => $product->trend, 'age' => $product->first_scrape_date])
+        @php($nextCheckLabel = $showNextCheck ? null : ($product->nextCheckShortLabel() ?? ($product->paused ? __('Paused') : null)))
+
+        @include('components.price-aggregates', ['aggregates' => $product->price_aggregates, 'trend' => $product->trend, 'age' => $product->first_scrape_date, 'nextCheck' => $nextCheckLabel])
 
         @if ($showNextCheck)
             @include('components.next-check-countdown', ['product' => $product])

--- a/resources/views/components/livewire/product-card-detail.blade.php
+++ b/resources/views/components/livewire/product-card-detail.blade.php
@@ -34,7 +34,9 @@
 
         @include('components.price-aggregates', ['aggregates' => $product->price_aggregates, 'trend' => $product->trend, 'age' => $product->first_scrape_date])
 
-        @include('components.next-check-countdown', ['product' => $product])
+        @if ($showNextCheck)
+            @include('components.next-check-countdown', ['product' => $product])
+        @endif
     </div>
 
     <x-filament-actions::modals />

--- a/resources/views/components/price-aggregates.blade.php
+++ b/resources/views/components/price-aggregates.blade.php
@@ -5,6 +5,7 @@
     use function Filament\Support\get_color_css_variables;
     $hideTrend ?? $hideTrend = true;
     $age = isset($age) ? Carbon::parse($age) : null;
+    $nextCheck = $nextCheck ?? null;
 @endphp
 <div
     class="py-2 px-4 gap-2 flex"
@@ -26,6 +27,11 @@
     @if ($age)
         <div class="text-xs text-gray-500 dark:text-gray-400 pr-2" title="First price on: {{ $age->toDateString() }}">
             Age: {{ $age->diffForHumans(syntax: CarbonInterface::DIFF_ABSOLUTE, short: true) }}
+        </div>
+    @endif
+    @if (! empty($nextCheck))
+        <div class="text-xs text-gray-500 dark:text-gray-400 pr-2">
+            {{ __('Next check') }}: {{ $nextCheck }}
         </div>
     @endif
     @if (! $hideTrend)

--- a/resources/views/components/product-badges.blade.php
+++ b/resources/views/components/product-badges.blade.php
@@ -14,25 +14,15 @@
 @endphp
 @if (! $product->is_last_scrape_successful || $product->is_notified_price || $latestPrice?->isUnavailable() || $product->paused || $verdict)
     <div {{ $attributes->merge(['class' => 'inline-flex gap-2 mt-1 flex-wrap']) }}>
-        @if ($verdict)
-            <div class="mt-1 whitespace-nowrap" data-verdict-color="{{ $verdictColor }}">
+        @if ($verdict && ! $product->is_notified_price)
+            <div class="mt-1 whitespace-nowrap" data-verdict-color="{{ $lowConfidence ? 'gray' : $verdictColor }}">
                 @include('components.icon-badge', [
-                    'hoverText' => $verdict,
+                    'hoverText' => $lowConfidence ? __('Not enough price history for a confident verdict') : $verdict,
                     'label' => $verdict,
-                    'color' => $verdictColor,
-                    'icon' => 'heroicon-m-sparkles',
+                    'color' => $lowConfidence ? 'gray' : $verdictColor,
+                    'icon' => $lowConfidence ? 'heroicon-m-question-mark-circle' : 'heroicon-m-sparkles',
                 ])
             </div>
-            @if ($lowConfidence)
-                <div class="mt-1 whitespace-nowrap">
-                    @include('components.icon-badge', [
-                        'hoverText' => __('Not enough price history for a confident verdict'),
-                        'label' => __('Low confidence'),
-                        'color' => 'gray',
-                        'icon' => 'heroicon-m-question-mark-circle',
-                    ])
-                </div>
-            @endif
         @endif
         @if ($product->paused)
             <div class="mt-1 whitespace-nowrap">

--- a/resources/views/components/product-badges.blade.php
+++ b/resources/views/components/product-badges.blade.php
@@ -9,7 +9,7 @@
         'average' => 'gray',
         'pricey' => 'warning',
         'wait' => 'danger',
-        default => 'success',
+        default => 'gray',
     };
 @endphp
 @if (! $product->is_last_scrape_successful || $product->is_notified_price || $latestPrice?->isUnavailable() || $product->paused || $verdict)
@@ -34,7 +34,6 @@
                 </div>
             @endif
         @endif
-
         @if ($product->paused)
             <div class="mt-1 whitespace-nowrap">
                 @include('components.icon-badge', [

--- a/resources/views/components/product-badges.blade.php
+++ b/resources/views/components/product-badges.blade.php
@@ -1,9 +1,40 @@
 @php
     $product = $product ?? $getRecord();
     $latestPrice = $product->getPriceCache()->first();
+    $verdict = data_get($product->insights_cache, 'dealScore.verdict');
+    $verdictKey = data_get($product->insights_cache, 'dealScore.verdictKey');
+    $lowConfidence = (bool) data_get($product->insights_cache, 'dealScore.lowConfidence', false);
+    $verdictColor = match ($verdictKey) {
+        'great', 'good' => 'success',
+        'average' => 'gray',
+        'pricey' => 'warning',
+        'wait' => 'danger',
+        default => 'success',
+    };
 @endphp
-@if (! $product->is_last_scrape_successful || $product->is_notified_price || $latestPrice?->isUnavailable() || $product->paused)
+@if (! $product->is_last_scrape_successful || $product->is_notified_price || $latestPrice?->isUnavailable() || $product->paused || $verdict)
     <div {{ $attributes->merge(['class' => 'inline-flex gap-2 mt-1 flex-wrap']) }}>
+        @if ($verdict)
+            <div class="mt-1 whitespace-nowrap" data-verdict-color="{{ $verdictColor }}">
+                @include('components.icon-badge', [
+                    'hoverText' => $verdict,
+                    'label' => $verdict,
+                    'color' => $verdictColor,
+                    'icon' => 'heroicon-m-sparkles',
+                ])
+            </div>
+            @if ($lowConfidence)
+                <div class="mt-1 whitespace-nowrap">
+                    @include('components.icon-badge', [
+                        'hoverText' => __('Not enough price history for a confident verdict'),
+                        'label' => __('Low confidence'),
+                        'color' => 'gray',
+                        'icon' => 'heroicon-m-question-mark-circle',
+                    ])
+                </div>
+            @endif
+        @endif
+
         @if ($product->paused)
             <div class="mt-1 whitespace-nowrap">
                 @include('components.icon-badge', [

--- a/resources/views/components/product-card.blade.php
+++ b/resources/views/components/product-card.blade.php
@@ -80,5 +80,5 @@
         </div>
     </div>
 
-    @livewire('product-card-detail', ['product' => $product], key('product-card-detail-'.$product->id))
+    @livewire('product-card-detail', ['product' => $product, 'showNextCheck' => false], key('product-card-detail-'.$product->id))
 </div>

--- a/resources/views/components/product-card.blade.php
+++ b/resources/views/components/product-card.blade.php
@@ -18,7 +18,7 @@
             :class="expanded ? 'rounded-bl-none' : ''"
         >
             <a class="flex gap-2" href="{{ $product->view_url }}">
-                <div class="w-20 h-20 min-w-20 m-2 rounded-md overflow-hidden p-1 flex items-center">
+                <div @class(['w-20 h-20 min-w-20 m-2 rounded-md overflow-hidden p-1 flex items-center', 'cursor-grab' => $draggable]) @if ($draggable) x-sortable-handle @endif>
                     <x-product-image :product="$product" />
                 </div>
                 <div class="my-1 flex flex-col min-w-0 justify-center" style="width: calc(100% - 5rem)">

--- a/resources/views/filament/widgets/dashboard/product-section.blade.php
+++ b/resources/views/filament/widgets/dashboard/product-section.blade.php
@@ -1,0 +1,32 @@
+@if ($products->isNotEmpty())
+    <div class="mb-8" wire:key="section-{{ $sectionKey }}">
+        <h3 class="fi-header-heading mb-4 flex gap-2 items-center text-xl md:text-2xl font-bold tracking-tight text-gray-950 dark:text-white">
+            <x-filament::icon :icon="$icon" class="h-5 w-5 text-gray-400 dark:text-gray-600" />
+            {{ $heading }}
+        </h3>
+        <div class="grid gap-6 md:grid-cols-2 2xl:grid-cols-3">
+            @foreach ($products as $product)
+                @php
+                    $verdict = data_get($product->insights_cache, 'dealScore.verdict');
+                    $lowConfidence = (bool) data_get($product->insights_cache, 'dealScore.lowConfidence', false);
+                @endphp
+                <div wire:key="{{ $sectionKey }}-{{ $product->id }}">
+                    @if ($verdict)
+                        <div class="mb-1 flex items-center gap-2">
+                            <span class="text-sm font-semibold text-primary-600 dark:text-primary-400">{{ $verdict }}</span>
+                            @if ($lowConfidence)
+                                @include('components.icon-badge', [
+                                    'hoverText' => __('Not enough price history for a confident verdict'),
+                                    'label' => __('Low confidence'),
+                                    'color' => 'gray',
+                                    'icon' => 'heroicon-m-question-mark-circle',
+                                ])
+                            @endif
+                        </div>
+                    @endif
+                    <x-product-card :product="$product" />
+                </div>
+            @endforeach
+        </div>
+    </div>
+@endif

--- a/resources/views/filament/widgets/dashboard/product-section.blade.php
+++ b/resources/views/filament/widgets/dashboard/product-section.blade.php
@@ -3,6 +3,9 @@
         <h3 class="fi-header-heading mb-4 flex gap-2 items-center text-xl md:text-2xl font-bold tracking-tight text-gray-950 dark:text-white">
             <x-filament::icon :icon="$icon" class="h-5 w-5 text-gray-400 dark:text-gray-600" />
             {{ $heading }}
+            <button type="button" wire:click="toggleSection('{{ $sectionKey }}')" class="ml-auto text-xs text-gray-400 hover:text-gray-600">
+                Hide
+            </button>
         </h3>
         <div class="grid gap-6 md:grid-cols-2 2xl:grid-cols-3">
             @foreach ($products as $product)

--- a/resources/views/filament/widgets/dashboard/product-section.blade.php
+++ b/resources/views/filament/widgets/dashboard/product-section.blade.php
@@ -3,38 +3,10 @@
         <h3 class="fi-header-heading mb-4 flex gap-2 items-center text-xl md:text-2xl font-bold tracking-tight text-gray-950 dark:text-white">
             <x-filament::icon :icon="$icon" class="h-5 w-5 text-gray-400 dark:text-gray-600" />
             {{ $heading }}
-            <button type="button" wire:click="toggleSection('{{ $sectionKey }}')" class="ml-auto text-xs text-gray-400 hover:text-gray-600">
-                Hide
-            </button>
         </h3>
         <div class="grid gap-6 md:grid-cols-2 2xl:grid-cols-3">
             @foreach ($products as $product)
-                @php
-                    $verdict = data_get($product->insights_cache, 'dealScore.verdict');
-                    $verdictKey = data_get($product->insights_cache, 'dealScore.verdictKey');
-                    $lowConfidence = (bool) data_get($product->insights_cache, 'dealScore.lowConfidence', false);
-                    $verdictColor = match ($verdictKey) {
-                        'great', 'good' => 'text-primary-600 dark:text-primary-400',
-                        'average' => 'text-gray-600 dark:text-gray-300',
-                        'pricey' => 'text-amber-600 dark:text-amber-400',
-                        'wait' => 'text-danger-600 dark:text-danger-400',
-                        default => 'text-primary-600 dark:text-primary-400',
-                    };
-                @endphp
                 <div wire:key="{{ $sectionKey }}-{{ $product->id }}">
-                    @if ($verdict)
-                        <div class="mb-1 flex items-center gap-2">
-                            <span class="text-sm font-semibold {{ $verdictColor }}">{{ $verdict }}</span>
-                            @if ($lowConfidence)
-                                @include('components.icon-badge', [
-                                    'hoverText' => __('Not enough price history for a confident verdict'),
-                                    'label' => __('Low confidence'),
-                                    'color' => 'gray',
-                                    'icon' => 'heroicon-m-question-mark-circle',
-                                ])
-                            @endif
-                        </div>
-                    @endif
                     <x-product-card :product="$product" />
                 </div>
             @endforeach

--- a/resources/views/filament/widgets/dashboard/product-section.blade.php
+++ b/resources/views/filament/widgets/dashboard/product-section.blade.php
@@ -8,12 +8,20 @@
             @foreach ($products as $product)
                 @php
                     $verdict = data_get($product->insights_cache, 'dealScore.verdict');
+                    $verdictKey = data_get($product->insights_cache, 'dealScore.verdictKey');
                     $lowConfidence = (bool) data_get($product->insights_cache, 'dealScore.lowConfidence', false);
+                    $verdictColor = match ($verdictKey) {
+                        'great', 'good' => 'text-primary-600 dark:text-primary-400',
+                        'average' => 'text-gray-600 dark:text-gray-300',
+                        'pricey' => 'text-amber-600 dark:text-amber-400',
+                        'wait' => 'text-danger-600 dark:text-danger-400',
+                        default => 'text-primary-600 dark:text-primary-400',
+                    };
                 @endphp
                 <div wire:key="{{ $sectionKey }}-{{ $product->id }}">
                     @if ($verdict)
                         <div class="mb-1 flex items-center gap-2">
-                            <span class="text-sm font-semibold text-primary-600 dark:text-primary-400">{{ $verdict }}</span>
+                            <span class="text-sm font-semibold {{ $verdictColor }}">{{ $verdict }}</span>
                             @if ($lowConfidence)
                                 @include('components.icon-badge', [
                                     'hoverText' => __('Not enough price history for a confident verdict'),

--- a/resources/views/filament/widgets/dashboard/stat-bar.blade.php
+++ b/resources/views/filament/widgets/dashboard/stat-bar.blade.php
@@ -1,0 +1,15 @@
+<div class="grid grid-cols-2 md:grid-cols-5 gap-4 mb-8">
+    @php($cells = [
+        ['label' => 'Tracked', 'value' => $stats['tracked']],
+        ['label' => 'All-time low', 'value' => $stats['atLowest']],
+        ['label' => 'Below average', 'value' => $stats['belowAverage']],
+        ['label' => 'Out of stock', 'value' => $stats['outOfStock']],
+        ['label' => 'Potential savings', 'value' => '$'.number_format($stats['potentialSavings'], 2)],
+    ])
+    @foreach ($cells as $cell)
+        <div class="fi-wi-stats-overview-stat rounded-xl bg-white dark:bg-gray-900 ring-1 ring-gray-950/5 dark:ring-white/10 p-4">
+            <div class="text-sm text-gray-500 dark:text-gray-400">{{ $cell['label'] }}</div>
+            <div class="text-2xl font-bold text-gray-950 dark:text-white">{{ $cell['value'] }}</div>
+        </div>
+    @endforeach
+</div>

--- a/resources/views/filament/widgets/product-stats-grouped.blade.php
+++ b/resources/views/filament/widgets/product-stats-grouped.blade.php
@@ -3,7 +3,7 @@
     $sectionLabels = ['stat_bar' => 'Summary stats', 'buy_now' => "What's good to buy now", 'recently_dropped' => 'Recently dropped', 'needs_attention' => 'Needs attention'];
 @endphp
 <x-filament-widgets::widget>
-    <x-filament::dropdown placement="bottom-end" class="mb-4">
+    <x-filament::dropdown placement="bottom-start" class="mb-4">
         <x-slot name="trigger">
             <x-filament::button size="sm" color="gray" icon="heroicon-m-adjustments-horizontal">Customize</x-filament::button>
         </x-slot>
@@ -46,15 +46,15 @@
                     data-category-signature="{{ $group['signature'] }}"
                     x-sortable-item="{{ $group['signature'] }}"
                 >
-                    <h3 class="fi-header-heading mb-4 flex gap-2 items-center text-xl md:text-2xl font-bold tracking-tight text-gray-950 dark:text-white">
-                        <button type="button" x-sortable-handle class="cursor-grab text-gray-400" title="Drag to reorder">
-                            <x-filament::icon icon="heroicon-o-bars-3" class="h-5 w-5" />
-                        </button>
-                        <button type="button" wire:click="toggleCategoryCollapse('{{ $group['signature'] }}')" class="text-gray-400">
-                            <x-filament::icon :icon="$group['collapsed'] ? 'heroicon-s-chevron-right' : 'heroicon-s-chevron-down'" class="h-5 w-5" />
-                        </button>
+                    <h3
+                        x-sortable-handle
+                        class="fi-header-heading mb-4 flex gap-2 items-center text-xl md:text-2xl font-bold tracking-tight text-gray-950 dark:text-white cursor-ns-resize"
+                    >
                         <x-filament::icon icon="heroicon-s-tag" class="h-5 w-5 text-gray-400 dark:text-gray-600" />
                         {{ $group['heading'] }}
+                        <button type="button" wire:click="toggleCategoryCollapse('{{ $group['signature'] }}')" class="ml-auto text-gray-400">
+                            <x-filament::icon :icon="$group['collapsed'] ? 'heroicon-s-chevron-right' : 'heroicon-s-chevron-down'" class="h-5 w-5" />
+                        </button>
                     </h3>
 
                     <div

--- a/resources/views/filament/widgets/product-stats-grouped.blade.php
+++ b/resources/views/filament/widgets/product-stats-grouped.blade.php
@@ -67,9 +67,8 @@
                                 wire:key="prod-{{ $product->id }}"
                                 data-product-id="{{ $product->id }}"
                                 x-sortable-item="{{ $product->id }}"
-                                x-sortable-handle
                             >
-                                <x-product-card :product="$product" />
+                                <x-product-card :product="$product" :draggable="true" />
                             </div>
                         @endforeach
                     </div>

--- a/resources/views/filament/widgets/product-stats-grouped.blade.php
+++ b/resources/views/filament/widgets/product-stats-grouped.blade.php
@@ -18,20 +18,46 @@
     @if (empty($groups))
         @livewire(NoProductsFound::class)
     @else
-        @foreach ($groups as $group)
-            <div class="mb-8">
-                <h3 class="fi-header-heading mb-4 flex gap-2 items-center text-xl md:text-2xl font-bold tracking-tight text-gray-950 dark:text-white">
-                    <x-filament::icon icon="heroicon-s-tag" class="h-5 w-5 pt-1 text-gray-400 dark:text-gray-600" />
-                    {{ $group['heading'] }}
-                </h3>
-                <div class="fi-wi-stats-overview-stats-ctn grid gap-6 md:grid-cols-2 2xl:grid-cols-3">
-                    @foreach ($group['products'] as $product)
-                        <div>
-                            <x-product-card :product="$product" />
-                        </div>
-                    @endforeach
+        <div
+            x-sortable
+            x-on:end.stop="$wire.reorderCategories($event.target.sortable.toArray())"
+        >
+            @foreach ($groups as $group)
+                <div
+                    class="mb-8"
+                    wire:key="cat-{{ $group['signature'] }}"
+                    data-category-signature="{{ $group['signature'] }}"
+                    x-sortable-item="{{ $group['signature'] }}"
+                >
+                    <h3 class="fi-header-heading mb-4 flex gap-2 items-center text-xl md:text-2xl font-bold tracking-tight text-gray-950 dark:text-white">
+                        <button type="button" x-sortable-handle class="cursor-grab text-gray-400" title="Drag to reorder">
+                            <x-filament::icon icon="heroicon-o-bars-3" class="h-5 w-5" />
+                        </button>
+                        <button type="button" wire:click="toggleCategoryCollapse('{{ $group['signature'] }}')" class="text-gray-400">
+                            <x-filament::icon :icon="$group['collapsed'] ? 'heroicon-s-chevron-right' : 'heroicon-s-chevron-down'" class="h-5 w-5" />
+                        </button>
+                        <x-filament::icon icon="heroicon-s-tag" class="h-5 w-5 text-gray-400 dark:text-gray-600" />
+                        {{ $group['heading'] }}
+                    </h3>
+
+                    <div
+                        @class(['fi-wi-stats-overview-stats-ctn grid gap-6 md:grid-cols-2 2xl:grid-cols-3', 'hidden' => $group['collapsed']])
+                        x-sortable
+                        x-on:end.stop="$wire.reorderProducts($event.target.sortable.toArray())"
+                    >
+                        @foreach ($group['products'] as $product)
+                            <div
+                                wire:key="prod-{{ $product->id }}"
+                                data-product-id="{{ $product->id }}"
+                                x-sortable-item="{{ $product->id }}"
+                                x-sortable-handle
+                            >
+                                <x-product-card :product="$product" />
+                            </div>
+                        @endforeach
+                    </div>
                 </div>
-            </div>
-        @endforeach
+            @endforeach
+        </div>
     @endif
 </x-filament-widgets::widget>

--- a/resources/views/filament/widgets/product-stats-grouped.blade.php
+++ b/resources/views/filament/widgets/product-stats-grouped.blade.php
@@ -2,6 +2,19 @@
     use App\Filament\Widgets\NoProductsFound;
 @endphp
 <x-filament-widgets::widget>
+    @foreach ($sections as $section)
+        @continue (! $section['visible'])
+        @if ($section['key'] === 'stat_bar')
+            @include('filament.widgets.dashboard.stat-bar', ['stats' => $sectionData['stat_bar']])
+        @elseif ($section['key'] === 'buy_now')
+            @include('filament.widgets.dashboard.product-section', ['sectionKey' => 'buy_now', 'heading' => "What's good to buy now", 'icon' => 'heroicon-s-bolt', 'products' => $sectionData['buy_now']])
+        @elseif ($section['key'] === 'recently_dropped')
+            @include('filament.widgets.dashboard.product-section', ['sectionKey' => 'recently_dropped', 'heading' => 'Recently dropped', 'icon' => 'heroicon-s-arrow-trending-down', 'products' => $sectionData['recently_dropped']])
+        @elseif ($section['key'] === 'needs_attention')
+            @include('filament.widgets.dashboard.product-section', ['sectionKey' => 'needs_attention', 'heading' => 'Needs attention', 'icon' => 'heroicon-s-exclamation-triangle', 'products' => $sectionData['needs_attention']])
+        @endif
+    @endforeach
+
     @if (empty($groups))
         @livewire(NoProductsFound::class)
     @else

--- a/resources/views/filament/widgets/product-stats-grouped.blade.php
+++ b/resources/views/filament/widgets/product-stats-grouped.blade.php
@@ -1,7 +1,24 @@
 @php
     use App\Filament\Widgets\NoProductsFound;
+    $sectionLabels = ['stat_bar' => 'Summary stats', 'buy_now' => "What's good to buy now", 'recently_dropped' => 'Recently dropped', 'needs_attention' => 'Needs attention'];
 @endphp
 <x-filament-widgets::widget>
+    <x-filament::dropdown placement="bottom-end" class="mb-4">
+        <x-slot name="trigger">
+            <x-filament::button size="sm" color="gray" icon="heroicon-m-adjustments-horizontal">Customize</x-filament::button>
+        </x-slot>
+        <x-filament::dropdown.list>
+            @foreach ($sections as $section)
+                <x-filament::dropdown.list.item wire:click="toggleSection('{{ $section['key'] }}')" wire:key="toggle-{{ $section['key'] }}">
+                    <span class="flex items-center gap-2">
+                        <x-filament::icon :icon="$section['visible'] ? 'heroicon-s-eye' : 'heroicon-s-eye-slash'" class="h-4 w-4" />
+                        {{ $sectionLabels[$section['key']] ?? $section['key'] }}
+                    </span>
+                </x-filament::dropdown.list.item>
+            @endforeach
+        </x-filament::dropdown.list>
+    </x-filament::dropdown>
+
     @foreach ($sections as $section)
         @continue (! $section['visible'])
         @if ($section['key'] === 'stat_bar')

--- a/resources/views/filament/widgets/product-stats-grouped.blade.php
+++ b/resources/views/filament/widgets/product-stats-grouped.blade.php
@@ -39,12 +39,20 @@
                             <x-filament::icon icon="heroicon-s-tag" class="h-5 w-5 text-gray-400 dark:text-gray-600" />
                             {{ $group['heading'] }}
                         </span>
-                        <button type="button" wire:click="toggleCategoryCollapse('{{ $group['signature'] }}')" class="ml-auto text-gray-400">
+                        <button
+                            type="button"
+                            wire:click="toggleCategoryCollapse('{{ $group['signature'] }}')"
+                            class="ml-auto text-gray-400"
+                            aria-expanded="{{ $group['collapsed'] ? 'false' : 'true' }}"
+                            aria-controls="cat-grid-{{ $group['signature'] }}"
+                            aria-label="{{ ($group['collapsed'] ? __('Expand') : __('Collapse')).' '.$group['heading'] }}"
+                        >
                             <x-filament::icon :icon="$group['collapsed'] ? 'heroicon-s-chevron-right' : 'heroicon-s-chevron-down'" class="h-5 w-5" />
                         </button>
                     </h3>
 
                     <div
+                        id="cat-grid-{{ $group['signature'] }}"
                         @class(['fi-wi-stats-overview-stats-ctn grid gap-6 md:grid-cols-2 2xl:grid-cols-3', 'hidden' => $group['collapsed']])
                         data-category-signature="{{ $group['signature'] }}"
                         x-sortable

--- a/resources/views/filament/widgets/product-stats-grouped.blade.php
+++ b/resources/views/filament/widgets/product-stats-grouped.blade.php
@@ -1,24 +1,7 @@
 @php
     use App\Filament\Widgets\NoProductsFound;
-    $sectionLabels = ['stat_bar' => 'Summary stats', 'buy_now' => "What's good to buy now", 'recently_dropped' => 'Recently dropped', 'needs_attention' => 'Needs attention'];
 @endphp
 <x-filament-widgets::widget>
-    <x-filament::dropdown placement="bottom-start" class="mb-4">
-        <x-slot name="trigger">
-            <x-filament::button size="sm" color="gray" icon="heroicon-m-adjustments-horizontal">Customize</x-filament::button>
-        </x-slot>
-        <x-filament::dropdown.list>
-            @foreach ($sections as $section)
-                <x-filament::dropdown.list.item wire:click="toggleSection('{{ $section['key'] }}')" wire:key="toggle-{{ $section['key'] }}">
-                    <span class="flex items-center gap-2">
-                        <x-filament::icon :icon="$section['visible'] ? 'heroicon-s-eye' : 'heroicon-s-eye-slash'" class="h-4 w-4" />
-                        {{ $sectionLabels[$section['key']] ?? $section['key'] }}
-                    </span>
-                </x-filament::dropdown.list.item>
-            @endforeach
-        </x-filament::dropdown.list>
-    </x-filament::dropdown>
-
     @foreach ($sections as $section)
         @continue (! $section['visible'])
         @if ($section['key'] === 'stat_bar')
@@ -47,11 +30,15 @@
                     x-sortable-item="{{ $group['signature'] }}"
                 >
                     <h3
-                        x-sortable-handle
-                        class="fi-header-heading mb-4 flex gap-2 items-center text-xl md:text-2xl font-bold tracking-tight text-gray-950 dark:text-white cursor-ns-resize"
+                        class="fi-header-heading mb-4 flex gap-2 items-center text-xl md:text-2xl font-bold tracking-tight text-gray-950 dark:text-white"
                     >
-                        <x-filament::icon icon="heroicon-s-tag" class="h-5 w-5 text-gray-400 dark:text-gray-600" />
-                        {{ $group['heading'] }}
+                        <span
+                            x-sortable-handle
+                            class="flex gap-2 items-center cursor-ns-resize"
+                        >
+                            <x-filament::icon icon="heroicon-s-tag" class="h-5 w-5 text-gray-400 dark:text-gray-600" />
+                            {{ $group['heading'] }}
+                        </span>
                         <button type="button" wire:click="toggleCategoryCollapse('{{ $group['signature'] }}')" class="ml-auto text-gray-400">
                             <x-filament::icon :icon="$group['collapsed'] ? 'heroicon-s-chevron-right' : 'heroicon-s-chevron-down'" class="h-5 w-5" />
                         </button>
@@ -59,8 +46,10 @@
 
                     <div
                         @class(['fi-wi-stats-overview-stats-ctn grid gap-6 md:grid-cols-2 2xl:grid-cols-3', 'hidden' => $group['collapsed']])
+                        data-category-signature="{{ $group['signature'] }}"
                         x-sortable
-                        x-on:end.stop="$wire.reorderProducts($event.target.sortable.toArray())"
+                        x-sortable-group="products"
+                        x-on:end.stop="$event.from === $event.to ? $wire.reorderProducts($event.to.sortable.toArray()) : $wire.moveProductToCategory($event.item.getAttribute('x-sortable-item'), $event.to.getAttribute('data-category-signature'), $event.to.sortable.toArray())"
                     >
                         @foreach ($group['products'] as $product)
                             <div

--- a/tests/Feature/Filament/EditUrlTest.php
+++ b/tests/Feature/Filament/EditUrlTest.php
@@ -80,13 +80,15 @@ class EditUrlTest extends TestCase
         Livewire::test(UrlsTableWidget::class, ['record' => $this->product])
             ->callTableAction('edit', $this->url, data: [
                 'url' => 'not-a-valid-url',
-                'price_factor' => 1,
+                'price_factor' => 5,
             ])
             ->assertHasTableActionErrors(['url']);
 
         $this->url->refresh();
 
+        // Neither the URL nor the price factor is persisted when the URL is rejected.
         $this->assertSame('https://example.com/product', $this->url->url);
+        $this->assertSame(1.0, (float) $this->url->price_factor);
     }
 
     public function test_show_page_widget_can_change_url_and_keeps_history()
@@ -116,12 +118,14 @@ class EditUrlTest extends TestCase
         Livewire::test(ProductUrlStats::class, ['record' => $this->product])
             ->callAction('edit', data: [
                 'url' => 'not-a-valid-url',
-                'price_factor' => 1,
+                'price_factor' => 5,
             ], arguments: ['url' => $this->url->getKey()])
             ->assertHasActionErrors(['url']);
 
         $this->url->refresh();
 
+        // Neither the URL nor the price factor is persisted when the URL is rejected.
         $this->assertSame('https://example.com/product', $this->url->url);
+        $this->assertSame(1.0, (float) $this->url->price_factor);
     }
 }

--- a/tests/Feature/Filament/EditUrlTest.php
+++ b/tests/Feature/Filament/EditUrlTest.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\ProductResource\Widgets\ProductUrlStats;
+use App\Filament\Resources\ProductResource\Widgets\UrlsTableWidget;
+use App\Models\Product;
+use App\Models\Store;
+use App\Models\Url;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+use Tests\Traits\ScraperTrait;
+
+class EditUrlTest extends TestCase
+{
+    use RefreshDatabase;
+    use ScraperTrait;
+
+    protected User $user;
+
+    protected Product $product;
+
+    protected Url $url;
+
+    protected Store $newStore;
+
+    protected string $newUrl = 'https://example2.com/product';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockScrape(100, 'Example Product');
+
+        $this->user = User::factory()->create();
+
+        $this->product = Product::factory()
+            ->for($this->user)
+            ->addUrlWithPrices('https://example.com/product', [10, 20, 30])
+            ->createOne();
+
+        /** @var Url $url */
+        $url = $this->product->urls()->first();
+        $this->url = $url;
+
+        $this->newStore = Store::factory()->createOne([
+            'domains' => [['domain' => 'example2.com']],
+        ]);
+
+        $this->actingAs($this->user);
+    }
+
+    public function test_edit_page_widget_can_change_url_and_keeps_history()
+    {
+        $historyPriceIds = $this->url->prices()->pluck('id')->all();
+
+        Livewire::test(UrlsTableWidget::class, ['record' => $this->product])
+            ->callTableAction('edit', $this->url, data: [
+                'url' => $this->newUrl,
+                'price_factor' => 1,
+            ])
+            ->assertHasNoTableActionErrors();
+
+        $this->url->refresh();
+
+        $this->assertSame($this->newUrl, $this->url->url);
+        $this->assertSame($this->newStore->getKey(), $this->url->store_id);
+
+        // Existing history rows survive, plus one freshly scraped price.
+        $this->assertSame(count($historyPriceIds) + 1, $this->url->prices()->count());
+        foreach ($historyPriceIds as $id) {
+            $this->assertDatabaseHas('prices', ['id' => $id]);
+        }
+    }
+
+    public function test_edit_page_widget_rejects_invalid_url_and_leaves_record_unchanged()
+    {
+        Livewire::test(UrlsTableWidget::class, ['record' => $this->product])
+            ->callTableAction('edit', $this->url, data: [
+                'url' => 'not-a-valid-url',
+                'price_factor' => 1,
+            ])
+            ->assertHasTableActionErrors(['url']);
+
+        $this->url->refresh();
+
+        $this->assertSame('https://example.com/product', $this->url->url);
+    }
+
+    public function test_show_page_widget_can_change_url_and_keeps_history()
+    {
+        $historyPriceIds = $this->url->prices()->pluck('id')->all();
+
+        Livewire::test(ProductUrlStats::class, ['record' => $this->product])
+            ->callAction('edit', data: [
+                'url' => $this->newUrl,
+                'price_factor' => 1,
+            ], arguments: ['url' => $this->url->getKey()])
+            ->assertHasNoActionErrors();
+
+        $this->url->refresh();
+
+        $this->assertSame($this->newUrl, $this->url->url);
+        $this->assertSame($this->newStore->getKey(), $this->url->store_id);
+
+        $this->assertSame(count($historyPriceIds) + 1, $this->url->prices()->count());
+        foreach ($historyPriceIds as $id) {
+            $this->assertDatabaseHas('prices', ['id' => $id]);
+        }
+    }
+
+    public function test_show_page_widget_rejects_invalid_url_and_leaves_record_unchanged()
+    {
+        Livewire::test(ProductUrlStats::class, ['record' => $this->product])
+            ->callAction('edit', data: [
+                'url' => 'not-a-valid-url',
+                'price_factor' => 1,
+            ], arguments: ['url' => $this->url->getKey()])
+            ->assertHasActionErrors(['url']);
+
+        $this->url->refresh();
+
+        $this->assertSame('https://example.com/product', $this->url->url);
+    }
+}

--- a/tests/Feature/Filament/HomeDashboardTest.php
+++ b/tests/Feature/Filament/HomeDashboardTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Pages\HomeDashboard;
+use App\Models\User;
+use App\Services\Dashboard\DashboardLayoutService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class HomeDashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function test_customize_action_seeds_current_section_visibility(): void
+    {
+        // Defaults: only buy_now visible.
+        Livewire::test(HomeDashboard::class)
+            ->mountAction('customize')
+            ->assertActionDataSet([
+                'stat_bar' => false,
+                'buy_now' => true,
+                'recently_dropped' => false,
+                'needs_attention' => false,
+            ]);
+    }
+
+    public function test_customize_action_persists_section_visibility(): void
+    {
+        Livewire::test(HomeDashboard::class)
+            ->callAction('customize', data: [
+                'stat_bar' => true,
+                'buy_now' => false,
+                'recently_dropped' => true,
+                'needs_attention' => false,
+            ])
+            ->assertDispatched('dashboard-sections-updated');
+
+        $layout = new DashboardLayoutService($this->user->fresh());
+        $this->assertTrue($layout->isSectionVisible('stat_bar'));
+        $this->assertFalse($layout->isSectionVisible('buy_now'));
+        $this->assertTrue($layout->isSectionVisible('recently_dropped'));
+        $this->assertFalse($layout->isSectionVisible('needs_attention'));
+    }
+}

--- a/tests/Feature/Filament/ProductTest.php
+++ b/tests/Feature/Filament/ProductTest.php
@@ -287,4 +287,39 @@ class ProductTest extends TestCase
 
         $this->assertCount(0, $product->tags);
     }
+
+    public function test_url_new_product_create_ignores_tags_owned_by_other_users()
+    {
+        $this->actingAs($this->user);
+
+        Url::query()->delete();
+        Product::query()->delete();
+        Store::query()->delete();
+
+        Store::factory()->createOne([
+            'domains' => [['domain' => 'example.com']],
+        ]);
+
+        $ownTag = Tag::factory()->create(['user_id' => $this->user->getKey(), 'name' => 'Mine']);
+        $otherUser = User::factory()->create();
+        $foreignTag = Tag::factory()->create(['user_id' => $otherUser->getKey(), 'name' => 'Theirs']);
+
+        $url = 'https://example.com/product/foreign_tags';
+
+        $this->mockScrape('$20.00', 'Foreign tag product', 'https://example.com/image.jpg');
+
+        Livewire::test(CreateProduct::class)
+            ->fillForm([
+                'url' => $url,
+                'tags' => [$ownTag->getKey(), $foreignTag->getKey()],
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        /** @var Product $product */
+        $product = Product::where('title', 'Foreign tag product')->first();
+
+        // Only the user's own tag is attached; a tampered foreign ID is dropped.
+        $this->assertEqualsCanonicalizing([$ownTag->getKey()], $product->tags->pluck('id')->all());
+    }
 }

--- a/tests/Feature/Filament/ProductTest.php
+++ b/tests/Feature/Filament/ProductTest.php
@@ -7,6 +7,7 @@ use App\Filament\Resources\ProductResource;
 use App\Filament\Resources\ProductResource\Pages\CreateProduct;
 use App\Models\Product;
 use App\Models\Store;
+use App\Models\Tag;
 use App\Models\Url;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -178,5 +179,112 @@ class ProductTest extends TestCase
         $scrapedCache = $product->getPriceCache();
         $this->assertSame(800.01, $scrapedCache->first()->getPrice());
         $this->assertSame($url, $scrapedCache->first()->getUrl());
+    }
+
+    public function test_url_new_product_create_with_tags()
+    {
+        $this->actingAs($this->user);
+
+        Url::query()->delete();
+        Product::query()->delete();
+        Store::query()->delete();
+
+        Store::factory()->createOne([
+            'domains' => [['domain' => 'example.com']],
+        ]);
+
+        $tagA = Tag::factory()->create(['user_id' => $this->user->getKey(), 'name' => 'Groceries']);
+        $tagB = Tag::factory()->create(['user_id' => $this->user->getKey(), 'name' => 'Health']);
+
+        $url = 'https://example.com/product/create_with_tags';
+
+        $this->mockScrape('$42.00', 'Tagged product', 'https://example.com/image.jpg');
+
+        Livewire::test(CreateProduct::class)
+            ->fillForm([
+                'url' => $url,
+                'tags' => [$tagA->getKey(), $tagB->getKey()],
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        /** @var Product $product */
+        $product = Product::where('title', 'Tagged product')->first();
+
+        $this->assertEqualsCanonicalizing(
+            [$tagA->getKey(), $tagB->getKey()],
+            $product->tags->pluck('id')->all(),
+        );
+    }
+
+    public function test_url_existing_product_create_merges_tags()
+    {
+        $this->actingAs($this->user);
+
+        Url::query()->delete();
+        Product::query()->delete();
+        Store::query()->delete();
+
+        $existingTag = Tag::factory()->create(['user_id' => $this->user->getKey(), 'name' => 'Existing']);
+        $newTag = Tag::factory()->create(['user_id' => $this->user->getKey(), 'name' => 'Added']);
+
+        $product = Product::factory()->create([
+            'title' => 'Product with a tag',
+            'user_id' => $this->user->getKey(),
+        ]);
+        $product->tags()->attach($existingTag);
+
+        Store::factory()->createOne([
+            'domains' => [['domain' => 'example.com']],
+        ]);
+
+        $url = 'https://example.com/product/merge_tags';
+
+        $this->mockScrape('$10.00', 'Product with a tag', 'https://example.com/image.jpg');
+
+        Livewire::test(CreateProduct::class)
+            ->fillForm([
+                'product_id' => $product->getKey(),
+                'url' => $url,
+                'tags' => [$newTag->getKey()],
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $product->refresh();
+
+        $this->assertEqualsCanonicalizing(
+            [$existingTag->getKey(), $newTag->getKey()],
+            $product->tags->pluck('id')->all(),
+        );
+    }
+
+    public function test_url_new_product_create_without_tags_has_no_tags()
+    {
+        $this->actingAs($this->user);
+
+        Url::query()->delete();
+        Product::query()->delete();
+        Store::query()->delete();
+
+        Store::factory()->createOne([
+            'domains' => [['domain' => 'example.com']],
+        ]);
+
+        $url = 'https://example.com/product/no_tags';
+
+        $this->mockScrape('$15.00', 'Untagged product', 'https://example.com/image.jpg');
+
+        Livewire::test(CreateProduct::class)
+            ->fillForm([
+                'url' => $url,
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        /** @var Product $product */
+        $product = Product::where('title', 'Untagged product')->first();
+
+        $this->assertCount(0, $product->tags);
     }
 }

--- a/tests/Feature/Livewire/ProductCardDetailTest.php
+++ b/tests/Feature/Livewire/ProductCardDetailTest.php
@@ -18,12 +18,11 @@ class ProductCardDetailTest extends TestCase
         $user = User::factory()->create();
         $this->actingAs($user);
 
-        // Paused products render the "Next check: Paused" branch of the countdown.
+        // `paused` is the sole trigger for the countdown's "Next check: Paused"
+        // branch; the price_cache row just lets the card body render.
         return Product::factory()->create([
             'user_id' => $user->id,
-            'status' => 'p',
             'paused' => true,
-            'current_price' => 100.0,
             'price_cache' => [['price' => 100.0, 'date' => now()->toDateString(), 'history' => []]],
         ]);
     }

--- a/tests/Feature/Livewire/ProductCardDetailTest.php
+++ b/tests/Feature/Livewire/ProductCardDetailTest.php
@@ -13,33 +13,41 @@ class ProductCardDetailTest extends TestCase
 {
     use RefreshDatabase;
 
-    private function pausedProduct(): Product
+    private function scheduledProduct(): Product
     {
         $user = User::factory()->create();
         $this->actingAs($user);
 
-        // `paused` is the sole trigger for the countdown's "Next check: Paused"
-        // branch; the price_cache row just lets the card body render.
-        return Product::factory()->create([
+        // A future check with price history so both the live countdown and the
+        // static label branches have data to render.
+        $product = Product::factory()->create([
             'user_id' => $user->id,
-            'paused' => true,
+            'refresh_interval' => 7200,
             'price_cache' => [['price' => 100.0, 'date' => now()->toDateString(), 'history' => []]],
         ]);
+
+        $product->forceFill(['next_check_at' => now()->addMinutes(70)])->saveQuietly();
+
+        return $product;
     }
 
-    public function test_next_check_shown_by_default(): void
+    public function test_live_countdown_shown_by_default(): void
     {
-        $product = $this->pausedProduct();
+        $product = $this->scheduledProduct();
 
+        // `setInterval` only appears in the live-countdown Alpine component.
         Livewire::test(ProductCardDetail::class, ['product' => $product])
-            ->assertSee('Next check');
+            ->assertSee('Next check')
+            ->assertSee('setInterval');
     }
 
-    public function test_next_check_hidden_when_disabled(): void
+    public function test_static_next_check_shown_when_countdown_disabled(): void
     {
-        $product = $this->pausedProduct();
+        $product = $this->scheduledProduct();
 
         Livewire::test(ProductCardDetail::class, ['product' => $product, 'showNextCheck' => false])
-            ->assertDontSee('Next check');
+            ->assertSee('Next check')
+            ->assertSee($product->nextCheckShortLabel())
+            ->assertDontSee('setInterval');
     }
 }

--- a/tests/Feature/Livewire/ProductCardDetailTest.php
+++ b/tests/Feature/Livewire/ProductCardDetailTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\ProductCardDetail;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ProductCardDetailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function pausedProduct(): Product
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        // Paused products render the "Next check: Paused" branch of the countdown.
+        return Product::factory()->create([
+            'user_id' => $user->id,
+            'status' => 'p',
+            'paused' => true,
+            'current_price' => 100.0,
+            'price_cache' => [['price' => 100.0, 'date' => now()->toDateString(), 'history' => []]],
+        ]);
+    }
+
+    public function test_next_check_shown_by_default(): void
+    {
+        $product = $this->pausedProduct();
+
+        Livewire::test(ProductCardDetail::class, ['product' => $product])
+            ->assertSee('Next check');
+    }
+
+    public function test_next_check_hidden_when_disabled(): void
+    {
+        $product = $this->pausedProduct();
+
+        Livewire::test(ProductCardDetail::class, ['product' => $product, 'showNextCheck' => false])
+            ->assertDontSee('Next check');
+    }
+}

--- a/tests/Feature/Models/ProductNextCheckTest.php
+++ b/tests/Feature/Models/ProductNextCheckTest.php
@@ -80,6 +80,15 @@ class ProductNextCheckTest extends TestCase
         $this->assertSame('2d', $product->nextCheckShortLabel());
     }
 
+    public function test_next_check_short_label_promotes_to_one_day_when_hours_round_up(): void
+    {
+        $product = Product::factory()->create(['refresh_interval' => 86400]);
+        // 23h40m rounds to 24 hours, which must display as "1d", not "24h".
+        $product->forceFill(['next_check_at' => now()->addMinutes((23 * 60) + 40)])->saveQuietly();
+
+        $this->assertSame('1d', $product->nextCheckShortLabel());
+    }
+
     public function test_next_check_short_label_uses_less_than_hour(): void
     {
         $product = Product::factory()->create(['refresh_interval' => 3600]);

--- a/tests/Feature/Models/ProductNextCheckTest.php
+++ b/tests/Feature/Models/ProductNextCheckTest.php
@@ -63,4 +63,36 @@ class ProductNextCheckTest extends TestCase
 
         $this->assertNull($product->currentCheckPeriodStart());
     }
+
+    public function test_next_check_short_label_rounds_to_hours(): void
+    {
+        $product = Product::factory()->create(['refresh_interval' => 7200]);
+        $product->forceFill(['next_check_at' => now()->addMinutes(70)])->saveQuietly();
+
+        $this->assertSame('1h', $product->nextCheckShortLabel());
+    }
+
+    public function test_next_check_short_label_rounds_to_days(): void
+    {
+        $product = Product::factory()->create(['refresh_interval' => 172800]);
+        $product->forceFill(['next_check_at' => now()->addHours(47)])->saveQuietly();
+
+        $this->assertSame('2d', $product->nextCheckShortLabel());
+    }
+
+    public function test_next_check_short_label_uses_less_than_hour(): void
+    {
+        $product = Product::factory()->create(['refresh_interval' => 3600]);
+        $product->forceFill(['next_check_at' => now()->addMinutes(20)])->saveQuietly();
+
+        $this->assertSame('<1h', $product->nextCheckShortLabel());
+    }
+
+    public function test_next_check_short_label_is_null_when_paused(): void
+    {
+        $product = Product::factory()->create(['refresh_interval' => 3600, 'paused' => true]);
+        $product->forceFill(['next_check_at' => now()->addMinutes(30)])->saveQuietly();
+
+        $this->assertNull($product->nextCheckShortLabel());
+    }
 }

--- a/tests/Feature/Models/UrlTest.php
+++ b/tests/Feature/Models/UrlTest.php
@@ -567,6 +567,71 @@ class UrlTest extends TestCase
 
     }
 
+    public function test_change_url_re_resolves_store_and_keeps_history()
+    {
+        $this->actingAs($this->user);
+
+        $this->mockScrape(100, 'Example Product');
+        /** @var Url $url */
+        $url = Url::createFromUrl(self::TEST_URL, userId: $this->user->getKey());
+
+        // An extra historical price so we can prove the series is retained.
+        $url->prices()->create([
+            'price' => 90,
+            'unit_price' => 90,
+            'price_factor' => 1,
+            'store_id' => $this->store->getKey(),
+        ]);
+
+        $historyPriceIds = $url->prices()->pluck('id')->all();
+        $this->assertCount(2, $historyPriceIds);
+
+        $newStore = Store::factory()->createOne([
+            'domains' => [['domain' => 'example2.com']],
+        ]);
+        $newUrl = 'https://example2.com/product';
+
+        $this->assertTrue($url->changeUrl($newUrl));
+
+        $url->refresh();
+
+        // URL re-pointed and store re-resolved from the new domain.
+        $this->assertSame($newUrl, $url->url);
+        $this->assertSame($newStore->getKey(), $url->store_id);
+
+        // The original history rows are untouched (retained on the same record).
+        $this->assertSame(
+            $historyPriceIds,
+            Price::whereIn('id', $historyPriceIds)->orderBy('id')->pluck('id')->all(),
+        );
+
+        // Exactly one fresh price was appended, recorded against the new store.
+        $this->assertSame(count($historyPriceIds) + 1, $url->prices()->count());
+        $newPrice = $url->prices()->whereNotIn('id', $historyPriceIds)->sole();
+        $this->assertSame($newStore->getKey(), $newPrice->store_id);
+    }
+
+    public function test_change_url_leaves_record_unchanged_when_url_cannot_resolve()
+    {
+        $this->actingAs($this->user);
+
+        $this->mockScrape(100, 'Example Product');
+        /** @var Url $url */
+        $url = Url::createFromUrl(self::TEST_URL, userId: $this->user->getKey());
+
+        $originalStoreId = $url->store_id;
+        $countBefore = $url->prices()->count();
+
+        // Domain with no matching store, and auto-create disabled so it cannot resolve.
+        $this->assertFalse($url->changeUrl('https://no-store-here.test/product', createStore: false));
+
+        $url->refresh();
+
+        $this->assertSame(self::TEST_URL, $url->url);
+        $this->assertSame($originalStoreId, $url->store_id);
+        $this->assertSame($countBefore, $url->prices()->count());
+    }
+
     protected function createOneProductWithUrlAndPrices(string $url = 'https://example.com', array $prices = [10, 15, 20], array $attrs = []): Product
     {
         return Product::factory()

--- a/tests/Feature/Services/Dashboard/DashboardLayoutServiceTest.php
+++ b/tests/Feature/Services/Dashboard/DashboardLayoutServiceTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests\Feature\Services\Dashboard;
+
+use App\Models\User;
+use App\Services\Dashboard\DashboardLayoutService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DashboardLayoutServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_defaults_when_no_settings(): void
+    {
+        $user = User::factory()->create(['settings' => []]);
+        $service = new DashboardLayoutService($user);
+
+        $keys = array_column($service->sections(), 'key');
+        $this->assertSame(DashboardLayoutService::SECTION_KEYS, $keys);
+        $this->assertTrue($service->isSectionVisible('buy_now'));
+        $this->assertSame([], $service->categoryOrder());
+        $this->assertFalse($service->isCategoryCollapsed('3-7'));
+    }
+
+    public function test_toggle_section_persists_and_flips(): void
+    {
+        $user = User::factory()->create(['settings' => []]);
+        $service = new DashboardLayoutService($user);
+
+        $service->toggleSection('buy_now');
+
+        $this->assertFalse($service->isSectionVisible('buy_now'));
+        $this->assertFalse((new DashboardLayoutService($user->fresh()))->isSectionVisible('buy_now'));
+    }
+
+    public function test_toggle_section_ignores_unknown_key(): void
+    {
+        $user = User::factory()->create(['settings' => []]);
+        $service = new DashboardLayoutService($user);
+
+        $service->toggleSection('not_a_section');
+
+        $this->assertCount(4, $service->sections());
+    }
+
+    public function test_collapse_persists(): void
+    {
+        $user = User::factory()->create(['settings' => []]);
+        $service = new DashboardLayoutService($user);
+
+        $service->toggleCategoryCollapse('3-7');
+
+        $this->assertTrue($service->isCategoryCollapsed('3-7'));
+        $service->toggleCategoryCollapse('3-7');
+        $this->assertFalse($service->isCategoryCollapsed('3-7'));
+    }
+
+    public function test_set_category_order_persists(): void
+    {
+        $user = User::factory()->create(['settings' => []]);
+        $service = new DashboardLayoutService($user);
+
+        $service->setCategoryOrder(['12', '3-7', 'uncategorized']);
+
+        $this->assertSame(['12', '3-7', 'uncategorized'], $user->fresh()->settings['dashboard']['categories']['order']);
+    }
+}

--- a/tests/Feature/Services/Dashboard/DashboardLayoutServiceTest.php
+++ b/tests/Feature/Services/Dashboard/DashboardLayoutServiceTest.php
@@ -19,6 +19,9 @@ class DashboardLayoutServiceTest extends TestCase
         $keys = array_column($service->sections(), 'key');
         $this->assertSame(DashboardLayoutService::SECTION_KEYS, $keys);
         $this->assertTrue($service->isSectionVisible('buy_now'));
+        $this->assertFalse($service->isSectionVisible('stat_bar'));
+        $this->assertFalse($service->isSectionVisible('recently_dropped'));
+        $this->assertFalse($service->isSectionVisible('needs_attention'));
         $this->assertSame([], $service->categoryOrder());
         $this->assertFalse($service->isCategoryCollapsed('3-7'));
     }
@@ -32,6 +35,27 @@ class DashboardLayoutServiceTest extends TestCase
 
         $this->assertFalse($service->isSectionVisible('buy_now'));
         $this->assertFalse((new DashboardLayoutService($user->fresh()))->isSectionVisible('buy_now'));
+    }
+
+    public function test_toggle_section_flips_from_hidden_default(): void
+    {
+        $user = User::factory()->create(['settings' => []]);
+        $service = new DashboardLayoutService($user);
+
+        $service->toggleSection('stat_bar');
+
+        $this->assertTrue($service->isSectionVisible('stat_bar'));
+        $this->assertTrue((new DashboardLayoutService($user->fresh()))->isSectionVisible('stat_bar'));
+    }
+
+    public function test_stored_preference_overrides_default(): void
+    {
+        $user = User::factory()->create([
+            'settings' => ['dashboard' => ['sections' => ['stat_bar' => ['visible' => true]]]],
+        ]);
+        $service = new DashboardLayoutService($user);
+
+        $this->assertTrue($service->isSectionVisible('stat_bar'));
     }
 
     public function test_toggle_section_ignores_unknown_key(): void

--- a/tests/Feature/Services/Dashboard/DashboardLayoutServiceTest.php
+++ b/tests/Feature/Services/Dashboard/DashboardLayoutServiceTest.php
@@ -58,6 +58,29 @@ class DashboardLayoutServiceTest extends TestCase
         $this->assertTrue($service->isSectionVisible('stat_bar'));
     }
 
+    public function test_set_section_visible_persists_explicit_value(): void
+    {
+        $user = User::factory()->create(['settings' => []]);
+        $service = new DashboardLayoutService($user);
+
+        $service->setSectionVisible('buy_now', false);
+        $service->setSectionVisible('stat_bar', true);
+
+        $fresh = new DashboardLayoutService($user->fresh());
+        $this->assertFalse($fresh->isSectionVisible('buy_now'));
+        $this->assertTrue($fresh->isSectionVisible('stat_bar'));
+    }
+
+    public function test_set_section_visible_ignores_unknown_key(): void
+    {
+        $user = User::factory()->create(['settings' => []]);
+        $service = new DashboardLayoutService($user);
+
+        $service->setSectionVisible('not_a_section', true);
+
+        $this->assertNull(data_get($user->fresh()->settings, 'dashboard.sections.not_a_section'));
+    }
+
     public function test_toggle_section_ignores_unknown_key(): void
     {
         $user = User::factory()->create(['settings' => []]);

--- a/tests/Feature/Services/Dashboard/DashboardSectionsTest.php
+++ b/tests/Feature/Services/Dashboard/DashboardSectionsTest.php
@@ -2,7 +2,9 @@
 
 namespace Tests\Feature\Services\Dashboard;
 
+use App\Enums\StockStatus;
 use App\Models\Product;
+use App\Models\Url;
 use App\Models\User;
 use App\Services\Dashboard\DashboardSections;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -93,5 +95,155 @@ class DashboardSectionsTest extends TestCase
         $ids = (new DashboardSections($this->user))->needsAttention()->pluck('id');
 
         $this->assertTrue($ids->contains($product->id));
+    }
+
+    /**
+     * Build a product with a single URL and a real, dated price history via
+     * `addUrlWithPrices()` (backdates each price by day index, so the last
+     * price in `$prices` becomes `current_price`).
+     */
+    private function productWithPrices(array $prices, array $attrs = []): Product
+    {
+        return Product::factory()
+            ->addUrlWithPrices('https://example.com/'.uniqid(), $prices)
+            ->create(array_merge([
+                'user_id' => $this->user->id,
+                'status' => 'p',
+            ], $attrs));
+    }
+
+    public function test_stat_bar_tracked_counts_only_products_with_price_and_cache(): void
+    {
+        // Real, trackable product: current_price > 0 and non-empty price_cache.
+        $tracked = $this->productWithPrices([60, 60, 30]);
+
+        // current_price is 0 -- excluded from "tracked".
+        $zeroPrice = Product::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'p',
+            'current_price' => 0,
+            'price_cache' => [['price' => 0, 'history' => []]],
+        ]);
+
+        // price_cache is empty -- excluded from "tracked".
+        $emptyCache = Product::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'p',
+            'current_price' => 50,
+            'price_cache' => [],
+        ]);
+
+        $this->assertSame(0.0, (float) $zeroPrice->fresh()->current_price);
+        $this->assertSame([], $emptyCache->fresh()->price_cache);
+
+        $stats = (new DashboardSections($this->user))->statBar();
+
+        $this->assertSame(1, $stats['tracked']);
+    }
+
+    public function test_stat_bar_potential_savings_sums_positive_drops_and_clamps_at_zero(): void
+    {
+        // avg = (60+50+30+40)/4 = 45, current (last price) = 40 -> savings = 5.
+        $this->productWithPrices([60, 50, 30, 40]);
+
+        // avg = (60+60+70)/3 = 63.33, current (last price) = 70 -> above average,
+        // savings clamps to 0 rather than going negative.
+        $this->productWithPrices([60, 60, 70]);
+
+        $stats = (new DashboardSections($this->user))->statBar();
+
+        $this->assertSame(5.0, $stats['potentialSavings']);
+    }
+
+    public function test_stat_bar_at_lowest_and_below_average_counts(): void
+    {
+        // current (30) <= min (30) -> Trend::Lowest.
+        $lowest = $this->productWithPrices([60, 60, 30]);
+
+        // current (40) < avg (45), > min (30) -> Trend::Down.
+        $down = $this->productWithPrices([60, 50, 30, 40]);
+
+        // current (70) > avg (63.33) -> Trend::Up, excluded from both counts.
+        $this->productWithPrices([60, 60, 70]);
+
+        // current (60) == avg (60) -> Trend::None, excluded from both counts.
+        $this->productWithPrices([60, 59, 61, 60]);
+
+        $this->assertSame('lowest', $lowest->fresh()->trend);
+        $this->assertSame('down', $down->fresh()->trend);
+
+        $stats = (new DashboardSections($this->user))->statBar();
+
+        $this->assertSame(1, $stats['atLowest']);
+        $this->assertSame(2, $stats['belowAverage']);
+    }
+
+    public function test_stat_bar_out_of_stock_counts_products_whose_price_cache_has_an_out_of_stock_row(): void
+    {
+        // One in-stock URL (keeps current_price > 0 / product tracked) plus one
+        // out-of-stock URL, so price_cache carries an out-of-stock row without
+        // zeroing current_price (mirrors ProductTest's multi-url convention).
+        $product = $this->productWithPrices([60, 60, 70]);
+
+        Url::factory()->createOne([
+            'product_id' => $product->getKey(),
+            'url' => 'https://example.com/oos',
+            'availability' => StockStatus::OutOfStock,
+        ]);
+
+        $product->updatePriceCache();
+
+        $this->assertGreaterThan(0, $product->fresh()->current_price);
+        $this->assertTrue(collect($product->fresh()->price_cache)->contains(
+            fn (array $row): bool => ($row['availability'] ?? null) === StockStatus::OutOfStock->value
+        ));
+
+        $stats = (new DashboardSections($this->user))->statBar();
+
+        $this->assertSame(1, $stats['outOfStock']);
+    }
+
+    public function test_recently_dropped_includes_products_with_a_recent_drop_and_excludes_others(): void
+    {
+        // Strictly decreasing: every earlier (backdated) price is greater than
+        // the current (latest) price -- matches scopeLowestPriceInDays(7).
+        $dropped = $this->productWithPrices([50, 40, 30]);
+
+        // Strictly increasing: no earlier price exceeds the current price --
+        // no drop recorded in the window.
+        $notDropped = $this->productWithPrices([30, 40, 50]);
+
+        $ids = (new DashboardSections($this->user))->recentlyDropped()->pluck('id');
+
+        $this->assertTrue($ids->contains($dropped->id));
+        $this->assertFalse($ids->contains($notDropped->id));
+    }
+
+    public function test_recently_dropped_sorts_by_drop_magnitude_descending(): void
+    {
+        // avg = 70, current = 40 -> drop magnitude 30.
+        $biggerDrop = $this->productWithPrices([100, 40]);
+
+        // avg = 55, current = 50 -> drop magnitude 5.
+        $smallerDrop = $this->productWithPrices([60, 50]);
+
+        $ids = (new DashboardSections($this->user))->recentlyDropped()->pluck('id')->values();
+
+        $this->assertSame([$biggerDrop->id, $smallerDrop->id], $ids->all());
+    }
+
+    public function test_recently_dropped_excludes_zero_price_products_despite_a_recorded_drop(): void
+    {
+        // Real price history that satisfies scopeLowestPriceInDays(7) (0 < every
+        // historical row once current_price is forced to 0 below), but the
+        // product is excluded via the shared `isTracked()` guard.
+        $product = $this->productWithPrices([50, 40, 30]);
+        $product->forceFill(['current_price' => 0])->saveQuietly();
+
+        $this->assertSame(0.0, (float) $product->fresh()->current_price);
+
+        $ids = (new DashboardSections($this->user))->recentlyDropped()->pluck('id');
+
+        $this->assertFalse($ids->contains($product->id));
     }
 }

--- a/tests/Feature/Services/Dashboard/DashboardSectionsTest.php
+++ b/tests/Feature/Services/Dashboard/DashboardSectionsTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Services\Dashboard;
+
+use App\Models\Product;
+use App\Models\User;
+use App\Services\Dashboard\DashboardSections;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DashboardSectionsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    /**
+     * Build a product whose materialized deal score equals the given value.
+     */
+    private function productWithDealScore(float $score, bool $isAllTimeLow = false): Product
+    {
+        $product = Product::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'p',
+            'current_price' => 100.0,
+            'price_cache' => [['price' => 100.0, 'date' => now()->toDateString()]],
+        ]);
+
+        $insights = $product->insights_cache ?? [];
+        $insights['dealScore'] = [
+            'score' => $score,
+            'verdictKey' => $score >= 8 ? 'great' : ($score >= 6 ? 'good' : 'average'),
+            'verdict' => 'test',
+            'isAllTimeLow' => $isAllTimeLow,
+            'lowConfidence' => false,
+        ];
+        $product->forceFill(['insights_cache' => $insights])->saveQuietly();
+
+        return $product->fresh();
+    }
+
+    public function test_buy_now_includes_only_score_six_and_above(): void
+    {
+        $good = $this->productWithDealScore(7.0);
+        $this->productWithDealScore(4.0); // excluded
+
+        $ids = (new DashboardSections($this->user))->buyNow()->pluck('id');
+
+        $this->assertTrue($ids->contains($good->id));
+        $this->assertCount(1, $ids);
+    }
+
+    public function test_buy_now_pins_all_time_low_first(): void
+    {
+        $highScore = $this->productWithDealScore(9.0, false);
+        $allTimeLow = $this->productWithDealScore(8.0, true);
+
+        $first = (new DashboardSections($this->user))->buyNow()->first();
+
+        $this->assertEquals($allTimeLow->id, $first->id);
+    }
+
+    public function test_needs_attention_relaxes_favourite_filter(): void
+    {
+        // A non-favourite product with a failed last scrape must still surface.
+        // `Product::is_last_scrape_successful` is driven by
+        // `PriceCacheDto::isLastScrapeSuccessful()`, which checks the `last_scrape`
+        // timestamp recency (must be < 24h old) -- there is no boolean
+        // "last_scrape_success" key in the cached array. We force staleness by
+        // backdating `last_scrape` on the cached row instead.
+        $product = Product::factory()
+            ->addUrlWithPrices('https://example.com/x', [100.0])
+            ->create([
+                'user_id' => $this->user->id,
+                'status' => 'p',
+                'favourite' => false,
+                'paused' => false,
+            ]);
+
+        $cache = $product->price_cache;
+        $cache[0]['last_scrape'] = now()->subDays(2)->toDateTimeString();
+        $product->forceFill(['price_cache' => $cache])->saveQuietly();
+
+        $this->assertFalse($product->fresh()->is_last_scrape_successful);
+
+        $ids = (new DashboardSections($this->user))->needsAttention()->pluck('id');
+
+        $this->assertTrue($ids->contains($product->id));
+    }
+}

--- a/tests/Feature/Services/Dashboard/DashboardSectionsTest.php
+++ b/tests/Feature/Services/Dashboard/DashboardSectionsTest.php
@@ -32,7 +32,7 @@ class DashboardSectionsTest extends TestCase
             'user_id' => $this->user->id,
             'status' => 'p',
             'current_price' => 100.0,
-            'price_cache' => [['price' => 100.0, 'date' => now()->toDateString()]],
+            'price_cache' => [['price' => 100.0, 'date' => now()->toDateString(), 'history' => []]],
         ]);
 
         $insights = $product->insights_cache ?? [];
@@ -69,6 +69,22 @@ class DashboardSectionsTest extends TestCase
         $this->assertEquals($allTimeLow->id, $first->id);
     }
 
+    public function test_buy_now_caps_to_six_highest_ranked(): void
+    {
+        // Seven qualifying products with distinct scores (6.1..6.7); only the
+        // top six by score should survive the BUY_NOW_LIMIT cap.
+        $products = collect(range(1, 7))
+            ->map(fn (int $i): Product => $this->productWithDealScore(6.0 + $i * 0.1));
+
+        $lowestScored = $products->first(); // score 6.1
+
+        $ids = (new DashboardSections($this->user))->buyNow()->pluck('id');
+
+        $this->assertCount(6, $ids);
+        $this->assertFalse($ids->contains($lowestScored->id));
+        $products->skip(1)->each(fn (Product $p) => $this->assertTrue($ids->contains($p->id)));
+    }
+
     public function test_needs_attention_relaxes_favourite_filter(): void
     {
         // A non-favourite product with a failed last scrape must still surface.
@@ -95,6 +111,30 @@ class DashboardSectionsTest extends TestCase
         $ids = (new DashboardSections($this->user))->needsAttention()->pluck('id');
 
         $this->assertTrue($ids->contains($product->id));
+    }
+
+    public function test_needs_attention_caps_to_fifteen(): void
+    {
+        // Sixteen qualifying (non-favourite, failed-scrape) products; only
+        // NEEDS_ATTENTION_LIMIT (15) should be returned.
+        collect(range(1, 16))->each(function (int $i): void {
+            $product = Product::factory()
+                ->addUrlWithPrices('https://example.com/needs-attention-'.$i, [100.0])
+                ->create([
+                    'user_id' => $this->user->id,
+                    'status' => 'p',
+                    'favourite' => false,
+                    'paused' => false,
+                ]);
+
+            $cache = $product->price_cache;
+            $cache[0]['last_scrape'] = now()->subDays(2)->toDateTimeString();
+            $product->forceFill(['price_cache' => $cache])->saveQuietly();
+        });
+
+        $ids = (new DashboardSections($this->user))->needsAttention()->pluck('id');
+
+        $this->assertCount(15, $ids);
     }
 
     /**
@@ -230,6 +270,23 @@ class DashboardSectionsTest extends TestCase
         $ids = (new DashboardSections($this->user))->recentlyDropped()->pluck('id')->values();
 
         $this->assertSame([$biggerDrop->id, $smallerDrop->id], $ids->all());
+    }
+
+    public function test_recently_dropped_caps_to_six_highest_ranked(): void
+    {
+        // Seven qualifying products with distinct drop magnitudes (10..70 in
+        // steps of 10); only the top six by drop size should survive the
+        // RECENTLY_DROPPED_LIMIT cap.
+        $products = collect(range(1, 7))
+            ->map(fn (int $i): Product => $this->productWithPrices([100 + $i * 20, 100]));
+
+        $smallestDrop = $products->first(); // drop magnitude 10
+
+        $ids = (new DashboardSections($this->user))->recentlyDropped()->pluck('id');
+
+        $this->assertCount(6, $ids);
+        $this->assertFalse($ids->contains($smallestDrop->id));
+        $products->skip(1)->each(fn (Product $p) => $this->assertTrue($ids->contains($p->id)));
     }
 
     public function test_recently_dropped_excludes_zero_price_products_despite_a_recorded_drop(): void

--- a/tests/Feature/View/ProductBadgesTest.php
+++ b/tests/Feature/View/ProductBadgesTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Tests\Feature\View;
+
+use App\Models\Product;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductBadgesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function productWithVerdict(string $verdictKey, string $verdict, bool $lowConfidence): Product
+    {
+        $product = Product::factory()->create([
+            'price_cache' => [['price' => 100.0, 'date' => now()->toDateString(), 'history' => []]],
+            // Clear notify thresholds so the verdict badge isn't suppressed by
+            // an incidental notify-match.
+            'notify_price' => null,
+            'notify_percent' => null,
+        ]);
+
+        $product->forceFill([
+            'insights_cache' => [
+                'dealScore' => [
+                    'verdict' => $verdict,
+                    'verdictKey' => $verdictKey,
+                    'lowConfidence' => $lowConfidence,
+                ],
+            ],
+        ])->saveQuietly();
+
+        return $product->fresh();
+    }
+
+    private function renderBadges(Product $product)
+    {
+        return $this->blade(
+            '<x-product-badges :product="$product" />',
+            ['product' => $product],
+        );
+    }
+
+    public function test_confident_verdict_uses_verdict_colour_and_verdict_tooltip(): void
+    {
+        $product = $this->productWithVerdict('great', 'Great time to buy', false);
+
+        $this->renderBadges($product)
+            ->assertSee('Great time to buy')
+            ->assertSee('data-verdict-color="success"', false);
+    }
+
+    public function test_low_confidence_verdict_is_greyed_with_confidence_tooltip(): void
+    {
+        $product = $this->productWithVerdict('great', 'Great time to buy', true);
+
+        $this->renderBadges($product)
+            ->assertSee('Great time to buy')
+            ->assertSee('Not enough price history for a confident verdict')
+            ->assertSee('data-verdict-color="gray"', false);
+    }
+
+    public function test_separate_low_confidence_badge_is_gone(): void
+    {
+        $product = $this->productWithVerdict('great', 'Great time to buy', true);
+
+        $this->renderBadges($product)
+            ->assertDontSee('Low confidence');
+    }
+
+    public function test_verdict_badge_hidden_when_notify_match(): void
+    {
+        $product = $this->productWithVerdict('great', 'Great time to buy', false);
+        // notify_price at/above current price makes is_notified_price true.
+        $product->forceFill(['notify_price' => 9999])->saveQuietly();
+
+        $this->assertTrue($product->fresh()->is_notified_price);
+
+        $this->renderBadges($product->fresh())
+            ->assertDontSee('Great time to buy')
+            ->assertSee('Notify match');
+    }
+}

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -86,13 +86,15 @@ class ProductStatsInteractionTest extends TestCase
 
     public function test_hidden_section_not_rendered(): void
     {
-        (new DashboardLayoutService($this->user))->toggleSection('stat_bar');
-
+        // stat_bar is hidden by default, so its stats must not render.
         Livewire::test(ProductStats::class)->assertDontSee('Potential savings');
     }
 
     public function test_needs_attention_section_colors_negative_verdict_correctly(): void
     {
+        // needs_attention is hidden by default; enable it so the product renders.
+        (new DashboardLayoutService($this->user))->toggleSection('needs_attention');
+
         // needs_attention doesn't filter on deal score, so a product with a
         // cached negative verdict (e.g. "wait") must not be styled with the
         // same positive/primary color used for a genuine great deal.

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -90,14 +90,14 @@ class ProductStatsInteractionTest extends TestCase
         Livewire::test(ProductStats::class)->assertDontSee('Potential savings');
     }
 
-    public function test_needs_attention_section_colors_negative_verdict_correctly(): void
+    public function test_needs_attention_section_shows_negative_verdict_as_non_positive_badge(): void
     {
+        // needs_attention doesn't filter on deal score, so a product with a
+        // cached negative verdict ("wait") must render a danger-coloured badge,
+        // never the success colour used for a genuine great deal.
         // needs_attention is hidden by default; enable it so the product renders.
         (new DashboardLayoutService($this->user))->toggleSection('needs_attention');
 
-        // needs_attention doesn't filter on deal score, so a product with a
-        // cached negative verdict (e.g. "wait") must not be styled with the
-        // same positive/primary color used for a genuine great deal.
         $product = Product::factory()->create([
             'user_id' => $this->user->id,
             'status' => 'p',
@@ -122,8 +122,8 @@ class ProductStatsInteractionTest extends TestCase
 
         Livewire::test(ProductStats::class)
             ->assertSee("Wait — it's expensive right now")
-            ->assertSee('text-danger-600')
-            ->assertDontSee('text-primary-600');
+            ->assertSeeHtml('data-verdict-color="danger"')
+            ->assertDontSeeHtml('data-verdict-color="success"');
     }
 
     public function test_category_group_exposes_collapse_control(): void
@@ -185,5 +185,38 @@ class ProductStatsInteractionTest extends TestCase
 
         Livewire::test(ProductStats::class)
             ->assertSeeHtml('wire:click="toggleSection(\'recently_dropped\')"');
+    }
+
+    public function test_buy_now_verdict_renders_as_success_badge(): void
+    {
+        Product::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'p',
+            'current_price' => 100.0,
+            'price_cache' => [['price' => 100.0, 'date' => now()->toDateString(), 'history' => []]],
+        ])->forceFill(['insights_cache' => ['dealScore' => [
+            'score' => 9.0, 'verdictKey' => 'great', 'verdict' => 'Great time to buy',
+            'isAllTimeLow' => true, 'lowConfidence' => false,
+        ]]])->saveQuietly();
+
+        Livewire::test(ProductStats::class)
+            ->assertSee('Great time to buy')
+            ->assertSeeHtml('data-verdict-color="success"');
+    }
+
+    public function test_section_header_has_no_hide_button(): void
+    {
+        Product::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'p',
+            'current_price' => 100.0,
+            'price_cache' => [['price' => 100.0, 'date' => now()->toDateString(), 'history' => []]],
+        ])->forceFill(['insights_cache' => ['dealScore' => [
+            'score' => 9.0, 'verdictKey' => 'great', 'verdict' => 'Great time to buy',
+            'isAllTimeLow' => true, 'lowConfidence' => false,
+        ]]])->saveQuietly();
+
+        Livewire::test(ProductStats::class)
+            ->assertDontSeeHtml('class="ml-auto text-xs text-gray-400 hover:text-gray-600"');
     }
 }

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -55,11 +55,93 @@ class ProductStatsInteractionTest extends TestCase
         $this->assertSame(['3-7', '12', 'uncategorized'], (new DashboardLayoutService($this->user->fresh()))->categoryOrder());
     }
 
-    public function test_toggle_section_persists(): void
+    public function test_move_product_to_category_replaces_tags(): void
     {
-        Livewire::test(ProductStats::class)->call('toggleSection', 'buy_now');
+        $from = Tag::factory()->create(['user_id' => $this->user->id]);
+        $to = Tag::factory()->create(['user_id' => $this->user->id]);
+        $product = Product::factory()->create(['user_id' => $this->user->id]);
+        $product->tags()->attach($from);
 
-        $this->assertFalse((new DashboardLayoutService($this->user->fresh()))->isSectionVisible('buy_now'));
+        Livewire::test(ProductStats::class)
+            ->call('moveProductToCategory', $product->id, (string) $to->id, [$product->id]);
+
+        $this->assertSame([$to->id], $product->fresh()->tags->pluck('id')->all());
+    }
+
+    public function test_move_product_to_multi_tag_category_syncs_full_set(): void
+    {
+        $product = Product::factory()->create(['user_id' => $this->user->id]);
+        $t1 = Tag::factory()->create(['user_id' => $this->user->id]);
+        $t2 = Tag::factory()->create(['user_id' => $this->user->id]);
+        $signature = collect([$t1->id, $t2->id])->sort()->values()->implode('-');
+
+        Livewire::test(ProductStats::class)
+            ->call('moveProductToCategory', $product->id, $signature, [$product->id]);
+
+        $this->assertEqualsCanonicalizing([$t1->id, $t2->id], $product->fresh()->tags->pluck('id')->all());
+    }
+
+    public function test_move_product_to_uncategorized_clears_tags(): void
+    {
+        $tag = Tag::factory()->create(['user_id' => $this->user->id]);
+        $product = Product::factory()->create(['user_id' => $this->user->id]);
+        $product->tags()->attach($tag);
+
+        Livewire::test(ProductStats::class)
+            ->call('moveProductToCategory', $product->id, 'uncategorized', [$product->id]);
+
+        $this->assertCount(0, $product->fresh()->tags);
+    }
+
+    public function test_move_product_reweights_destination_order(): void
+    {
+        $to = Tag::factory()->create(['user_id' => $this->user->id]);
+        $a = Product::factory()->create(['user_id' => $this->user->id, 'weight' => 0]);
+        $moved = Product::factory()->create(['user_id' => $this->user->id, 'weight' => 0]);
+        $b = Product::factory()->create(['user_id' => $this->user->id, 'weight' => 0]);
+
+        Livewire::test(ProductStats::class)
+            ->call('moveProductToCategory', $moved->id, (string) $to->id, [$a->id, $moved->id, $b->id]);
+
+        $this->assertSame(0, $a->fresh()->weight);
+        $this->assertSame(1, $moved->fresh()->weight);
+        $this->assertSame(2, $b->fresh()->weight);
+        $this->assertSame([$to->id], $moved->fresh()->tags->pluck('id')->all());
+    }
+
+    public function test_move_product_ignores_foreign_product(): void
+    {
+        $theirs = Product::factory()->create(['user_id' => User::factory()->create()->id]);
+        $myTag = Tag::factory()->create(['user_id' => $this->user->id]);
+
+        Livewire::test(ProductStats::class)
+            ->call('moveProductToCategory', $theirs->id, (string) $myTag->id, [$theirs->id]);
+
+        $this->assertCount(0, $theirs->fresh()->tags);
+    }
+
+    public function test_move_product_ignores_foreign_tag_in_signature(): void
+    {
+        $foreignTag = Tag::factory()->create(['user_id' => User::factory()->create()->id]);
+        $product = Product::factory()->create(['user_id' => $this->user->id]);
+
+        Livewire::test(ProductStats::class)
+            ->call('moveProductToCategory', $product->id, (string) $foreignTag->id, [$product->id]);
+
+        // Foreign tag is filtered out, so the product ends up uncategorised
+        // rather than attached to another user's tag.
+        $this->assertCount(0, $product->fresh()->tags);
+    }
+
+    public function test_product_lists_share_sortable_group_for_cross_category_drops(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);
+        $p = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 1, 'date' => now()->toDateString(), 'history' => []]]]);
+        $p->tags()->attach($tag);
+
+        Livewire::test(ProductStats::class)
+            ->assertSeeHtml('x-sortable-group="products"')
+            ->assertSeeHtml('$wire.moveProductToCategory(');
     }
 
     public function test_toggle_collapse_persists(): void
@@ -158,35 +240,11 @@ class ProductStatsInteractionTest extends TestCase
         Livewire::test(ProductStats::class)
             ->assertSeeHtml('x-sortable')
             ->assertSeeHtml('x-on:end.stop="$wire.reorderCategories($event.target.sortable.toArray())"')
-            ->assertSeeHtml('x-on:end.stop="$wire.reorderProducts($event.target.sortable.toArray())"')
+            ->assertSeeHtml('$wire.reorderProducts($event.to.sortable.toArray())')
             ->assertSeeHtml('data-category-signature="'.$tag->id.'"')
             ->assertSeeHtml('data-product-id="'.$p->id.'"')
             ->assertSeeHtml('x-sortable-item="'.$tag->id.'"')
             ->assertSeeHtml('x-sortable-item="'.$p->id.'"');
-    }
-
-    public function test_visible_section_listed_in_customize_control(): void
-    {
-        // A visible section (buy_now is visible by default) is toggleable via the
-        // customise dropdown (the section header no longer carries a Hide button).
-        Product::factory()->create([
-            'user_id' => $this->user->id,
-            'status' => 'p',
-            'current_price' => 100.0,
-            'price_cache' => [['price' => 100.0, 'date' => now()->toDateString(), 'history' => []]],
-        ])->forceFill(['insights_cache' => ['dealScore' => ['score' => 9.0, 'verdictKey' => 'great', 'verdict' => 'Great time to buy', 'isAllTimeLow' => true, 'lowConfidence' => false]]])->saveQuietly();
-
-        Livewire::test(ProductStats::class)
-            ->assertSeeHtml('wire:click="toggleSection(\'buy_now\')"');
-    }
-
-    public function test_hidden_section_still_listed_in_customize_control(): void
-    {
-        // Even a hidden section must appear in the customise control so it can be re-enabled.
-        (new DashboardLayoutService($this->user))->toggleSection('recently_dropped');
-
-        Livewire::test(ProductStats::class)
-            ->assertSeeHtml('wire:click="toggleSection(\'recently_dropped\')"');
     }
 
     public function test_buy_now_verdict_renders_as_success_badge(): void
@@ -252,19 +310,19 @@ class ProductStatsInteractionTest extends TestCase
             ->assertDontSeeHtml('cursor-grab'); // but without a drag handle
     }
 
-    public function test_customize_dropdown_opens_under_button(): void
-    {
-        Livewire::test(ProductStats::class)->assertSeeHtml('placement.bottom-start');
-    }
-
-    public function test_category_heading_is_drag_handle_with_chevron_on_right(): void
+    public function test_category_drag_handle_is_heading_icon_and_text_only(): void
     {
         $tag = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);
         $p = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 1, 'date' => now()->toDateString(), 'history' => []]]]);
         $p->tags()->attach($tag);
 
         Livewire::test(ProductStats::class)
-            ->assertSeeHtml('cursor-ns-resize')
+            // The drag handle is the inner span (icon + text) carrying the resize cursor.
+            ->assertSeeHtml('x-sortable-handle')
+            ->assertSeeHtml('class="flex gap-2 items-center cursor-ns-resize"')
+            // The <h3> heading row itself no longer carries the resize cursor / handle.
+            ->assertDontSeeHtml('dark:text-white cursor-ns-resize')
+            // Collapse chevron stays outside the handle, pushed to the right.
             ->assertSeeHtml('wire:click="toggleCategoryCollapse(\''.$tag->id.'\')"')
             ->assertSeeHtml('ml-auto text-gray-400')
             ->assertDontSeeHtml('Drag to reorder');

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -162,4 +162,13 @@ class ProductStatsInteractionTest extends TestCase
         Livewire::test(ProductStats::class)
             ->assertSeeHtml('wire:click="toggleSection(\'buy_now\')"');
     }
+
+    public function test_all_sections_listed_in_customize_control(): void
+    {
+        // Even a hidden section must appear in the customise control so it can be re-enabled.
+        (new DashboardLayoutService($this->user))->toggleSection('recently_dropped');
+
+        Livewire::test(ProductStats::class)
+            ->assertSeeHtml('wire:click="toggleSection(\'recently_dropped\')"');
+    }
 }

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -67,4 +67,26 @@ class ProductStatsInteractionTest extends TestCase
 
         $this->assertTrue((new DashboardLayoutService($this->user->fresh()))->isCategoryCollapsed('3-7'));
     }
+
+    public function test_buy_now_section_renders_when_visible(): void
+    {
+        $product = Product::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'p',
+            'current_price' => 100.0,
+            'price_cache' => [['price' => 100.0, 'date' => now()->toDateString(), 'history' => []]],
+        ]);
+        $insights = $product->insights_cache ?? [];
+        $insights['dealScore'] = ['score' => 9.0, 'verdictKey' => 'great', 'verdict' => 'Great time to buy', 'isAllTimeLow' => true, 'lowConfidence' => false];
+        $product->forceFill(['insights_cache' => $insights])->saveQuietly();
+
+        Livewire::test(ProductStats::class)->assertSee('Great time to buy');
+    }
+
+    public function test_hidden_section_not_rendered(): void
+    {
+        (new DashboardLayoutService($this->user))->toggleSection('stat_bar');
+
+        Livewire::test(ProductStats::class)->assertDontSee('Potential savings');
+    }
 }

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -219,4 +219,14 @@ class ProductStatsInteractionTest extends TestCase
         Livewire::test(ProductStats::class)
             ->assertDontSeeHtml('class="ml-auto text-xs text-gray-400 hover:text-gray-600"');
     }
+
+    public function test_product_image_is_the_drag_handle(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);
+        $p = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 1, 'date' => now()->toDateString(), 'history' => []]]]);
+        $p->tags()->attach($tag);
+
+        Livewire::test(ProductStats::class)
+            ->assertSeeHtml('w-20 h-20 min-w-20 m-2 rounded-md overflow-hidden p-1 flex items-center cursor-grab');
+    }
 }

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -229,4 +229,22 @@ class ProductStatsInteractionTest extends TestCase
         Livewire::test(ProductStats::class)
             ->assertSeeHtml('w-20 h-20 min-w-20 m-2 rounded-md overflow-hidden p-1 flex items-center cursor-grab');
     }
+
+    public function test_customize_dropdown_opens_under_button(): void
+    {
+        Livewire::test(ProductStats::class)->assertSeeHtml('placement.bottom-start');
+    }
+
+    public function test_category_heading_is_drag_handle_with_chevron_on_right(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);
+        $p = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 1, 'date' => now()->toDateString(), 'history' => []]]]);
+        $p->tags()->attach($tag);
+
+        Livewire::test(ProductStats::class)
+            ->assertSeeHtml('cursor-ns-resize')
+            ->assertSeeHtml('wire:click="toggleCategoryCollapse(\''.$tag->id.'\')"')
+            ->assertSeeHtml('ml-auto text-gray-400')
+            ->assertDontSeeHtml('Drag to reorder');
+    }
 }

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -165,8 +165,10 @@ class ProductStatsInteractionTest extends TestCase
             ->assertSeeHtml('x-sortable-item="'.$p->id.'"');
     }
 
-    public function test_section_exposes_hide_control(): void
+    public function test_visible_section_listed_in_customize_control(): void
     {
+        // A visible section (buy_now is visible by default) is toggleable via the
+        // customise dropdown (the section header no longer carries a Hide button).
         Product::factory()->create([
             'user_id' => $this->user->id,
             'status' => 'p',
@@ -178,7 +180,7 @@ class ProductStatsInteractionTest extends TestCase
             ->assertSeeHtml('wire:click="toggleSection(\'buy_now\')"');
     }
 
-    public function test_all_sections_listed_in_customize_control(): void
+    public function test_hidden_section_still_listed_in_customize_control(): void
     {
         // Even a hidden section must appear in the customise control so it can be re-enabled.
         (new DashboardLayoutService($this->user))->toggleSection('recently_dropped');
@@ -228,6 +230,26 @@ class ProductStatsInteractionTest extends TestCase
 
         Livewire::test(ProductStats::class)
             ->assertSeeHtml('w-20 h-20 min-w-20 m-2 rounded-md overflow-hidden p-1 flex items-center cursor-grab');
+    }
+
+    public function test_smart_section_card_is_not_draggable(): void
+    {
+        // A non-favourite product surfaces in buy_now (a smart section) but not
+        // in a draggable category group, so its card must omit the drag handle.
+        Product::factory()->create([
+            'user_id' => $this->user->id,
+            'favourite' => false,
+            'status' => 'p',
+            'current_price' => 100.0,
+            'price_cache' => [['price' => 100.0, 'date' => now()->toDateString(), 'history' => []]],
+        ])->forceFill(['insights_cache' => ['dealScore' => [
+            'score' => 9.0, 'verdictKey' => 'great', 'verdict' => 'Great time to buy',
+            'isAllTimeLow' => true, 'lowConfidence' => false,
+        ]]])->saveQuietly();
+
+        Livewire::test(ProductStats::class)
+            ->assertSee('Great time to buy')    // card rendered in the smart section
+            ->assertDontSeeHtml('cursor-grab'); // but without a drag handle
     }
 
     public function test_customize_dropdown_opens_under_button(): void

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -89,4 +89,37 @@ class ProductStatsInteractionTest extends TestCase
 
         Livewire::test(ProductStats::class)->assertDontSee('Potential savings');
     }
+
+    public function test_needs_attention_section_colors_negative_verdict_correctly(): void
+    {
+        // needs_attention doesn't filter on deal score, so a product with a
+        // cached negative verdict (e.g. "wait") must not be styled with the
+        // same positive/primary color used for a genuine great deal.
+        $product = Product::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'p',
+            'paused' => false,
+            'current_price' => 100.0,
+            'price_cache' => [[
+                'price' => 100.0,
+                'date' => now()->toDateString(),
+                'history' => [],
+                'last_scrape' => now()->subDays(2)->toDateTimeString(),
+            ]],
+        ]);
+        $insights = $product->insights_cache ?? [];
+        $insights['dealScore'] = [
+            'score' => 3.0,
+            'verdictKey' => 'wait',
+            'verdict' => "Wait — it's expensive right now",
+            'isAllTimeLow' => false,
+            'lowConfidence' => false,
+        ];
+        $product->forceFill(['insights_cache' => $insights])->saveQuietly();
+
+        Livewire::test(ProductStats::class)
+            ->assertSee("Wait — it's expensive right now")
+            ->assertSee('text-danger-600')
+            ->assertDontSee('text-primary-600');
+    }
 }

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -215,7 +215,11 @@ class ProductStatsInteractionTest extends TestCase
         $p->tags()->attach($tag);
 
         Livewire::test(ProductStats::class)
-            ->assertSeeHtml('wire:click="toggleCategoryCollapse(\''.$tag->id.'\')"');
+            ->assertSeeHtml('wire:click="toggleCategoryCollapse(\''.$tag->id.'\')"')
+            // Collapse control is announced to assistive tech: labelled, with state + target.
+            ->assertSeeHtml('aria-expanded="true"')
+            ->assertSeeHtml('aria-controls="cat-grid-'.$tag->id.'"')
+            ->assertSeeHtml('aria-label="Collapse Alpha"');
     }
 
     public function test_collapsed_category_grid_is_hidden(): void

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Widgets;
+
+use App\Filament\Widgets\ProductStats;
+use App\Models\Product;
+use App\Models\User;
+use App\Services\Dashboard\DashboardLayoutService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ProductStatsInteractionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    public function test_reorder_products_persists_weights(): void
+    {
+        $a = Product::factory()->create(['user_id' => $this->user->id, 'weight' => 0]);
+        $b = Product::factory()->create(['user_id' => $this->user->id, 'weight' => 0]);
+        $c = Product::factory()->create(['user_id' => $this->user->id, 'weight' => 0]);
+
+        Livewire::test(ProductStats::class)->call('reorderProducts', [$c->id, $a->id, $b->id]);
+
+        $this->assertSame(0, $c->fresh()->weight);
+        $this->assertSame(1, $a->fresh()->weight);
+        $this->assertSame(2, $b->fresh()->weight);
+    }
+
+    public function test_reorder_products_ignores_foreign_products(): void
+    {
+        $mine = Product::factory()->create(['user_id' => $this->user->id, 'weight' => 5]);
+        $theirs = Product::factory()->create(['user_id' => User::factory()->create()->id, 'weight' => 9]);
+
+        Livewire::test(ProductStats::class)->call('reorderProducts', [$theirs->id, $mine->id]);
+
+        $this->assertSame(9, $theirs->fresh()->weight); // untouched
+        $this->assertSame(0, $mine->fresh()->weight);   // theirs skipped without increment, mine is first owned id
+    }
+
+    public function test_reorder_categories_persists_order(): void
+    {
+        Livewire::test(ProductStats::class)->call('reorderCategories', ['3-7', '12', 'uncategorized']);
+
+        $this->assertSame(['3-7', '12', 'uncategorized'], (new DashboardLayoutService($this->user->fresh()))->categoryOrder());
+    }
+
+    public function test_toggle_section_persists(): void
+    {
+        Livewire::test(ProductStats::class)->call('toggleSection', 'buy_now');
+
+        $this->assertFalse((new DashboardLayoutService($this->user->fresh()))->isSectionVisible('buy_now'));
+    }
+
+    public function test_toggle_collapse_persists(): void
+    {
+        Livewire::test(ProductStats::class)->call('toggleCategoryCollapse', '3-7');
+
+        $this->assertTrue((new DashboardLayoutService($this->user->fresh()))->isCategoryCollapsed('3-7'));
+    }
+}

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -134,6 +134,19 @@ class ProductStatsInteractionTest extends TestCase
             ->assertSeeHtml('wire:click="toggleCategoryCollapse(\''.$tag->id.'\')"');
     }
 
+    public function test_collapsed_category_grid_is_hidden(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);
+        $p = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 1, 'date' => now()->toDateString(), 'history' => []]]]);
+        $p->tags()->attach($tag);
+
+        (new DashboardLayoutService($this->user))->toggleCategoryCollapse((string) $tag->id);
+
+        Livewire::test(ProductStats::class)
+            ->assertSeeHtml('data-category-signature="'.$tag->id.'"')
+            ->assertSeeHtml('class="fi-wi-stats-overview-stats-ctn grid gap-6 md:grid-cols-2 2xl:grid-cols-3 hidden"');
+    }
+
     public function test_category_group_exposes_sortable_containers(): void
     {
         $tag = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);

--- a/tests/Feature/Widgets/ProductStatsInteractionTest.php
+++ b/tests/Feature/Widgets/ProductStatsInteractionTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\Widgets;
 
 use App\Filament\Widgets\ProductStats;
 use App\Models\Product;
+use App\Models\Tag;
 use App\Models\User;
 use App\Services\Dashboard\DashboardLayoutService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -121,5 +122,44 @@ class ProductStatsInteractionTest extends TestCase
             ->assertSee("Wait — it's expensive right now")
             ->assertSee('text-danger-600')
             ->assertDontSee('text-primary-600');
+    }
+
+    public function test_category_group_exposes_collapse_control(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);
+        $p = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 1, 'date' => now()->toDateString(), 'history' => []]]]);
+        $p->tags()->attach($tag);
+
+        Livewire::test(ProductStats::class)
+            ->assertSeeHtml('wire:click="toggleCategoryCollapse(\''.$tag->id.'\')"');
+    }
+
+    public function test_category_group_exposes_sortable_containers(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);
+        $p = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 1, 'date' => now()->toDateString(), 'history' => []]]]);
+        $p->tags()->attach($tag);
+
+        Livewire::test(ProductStats::class)
+            ->assertSeeHtml('x-sortable')
+            ->assertSeeHtml('x-on:end.stop="$wire.reorderCategories($event.target.sortable.toArray())"')
+            ->assertSeeHtml('x-on:end.stop="$wire.reorderProducts($event.target.sortable.toArray())"')
+            ->assertSeeHtml('data-category-signature="'.$tag->id.'"')
+            ->assertSeeHtml('data-product-id="'.$p->id.'"')
+            ->assertSeeHtml('x-sortable-item="'.$tag->id.'"')
+            ->assertSeeHtml('x-sortable-item="'.$p->id.'"');
+    }
+
+    public function test_section_exposes_hide_control(): void
+    {
+        Product::factory()->create([
+            'user_id' => $this->user->id,
+            'status' => 'p',
+            'current_price' => 100.0,
+            'price_cache' => [['price' => 100.0, 'date' => now()->toDateString(), 'history' => []]],
+        ])->forceFill(['insights_cache' => ['dealScore' => ['score' => 9.0, 'verdictKey' => 'great', 'verdict' => 'Great time to buy', 'isAllTimeLow' => true, 'lowConfidence' => false]]])->saveQuietly();
+
+        Livewire::test(ProductStats::class)
+            ->assertSeeHtml('wire:click="toggleSection(\'buy_now\')"');
     }
 }

--- a/tests/Feature/Widgets/ProductStatsTest.php
+++ b/tests/Feature/Widgets/ProductStatsTest.php
@@ -306,4 +306,32 @@ class ProductStatsTest extends TestCase
         $this->assertEquals(50, $groupValues[0]['weight']);
         $this->assertEquals(50, $groupValues[1]['weight']);
     }
+
+    public function test_groups_include_stable_signature(): void
+    {
+        $tagA = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);
+        $tagB = Tag::factory()->create(['name' => 'Beta', 'weight' => 20, 'user_id' => $this->user->id]);
+
+        $product = Product::factory()->create([
+            'user_id' => $this->user->id,
+            'favourite' => true,
+            'status' => 'p',
+            'price_cache' => [['price' => 100.00, 'date' => now()->toDateString()]],
+        ]);
+        $product->tags()->attach([$tagB->id, $tagA->id]);
+
+        $uncategorized = Product::factory()->create([
+            'user_id' => $this->user->id,
+            'favourite' => true,
+            'status' => 'p',
+            'price_cache' => [['price' => 50.00, 'date' => now()->toDateString()]],
+        ]);
+
+        $groups = ProductStats::getProductsGrouped();
+        $signatures = array_column($groups, 'signature');
+
+        // Sorted tag ids joined by '-', regardless of attach order.
+        $this->assertContains(min($tagA->id, $tagB->id).'-'.max($tagA->id, $tagB->id), $signatures);
+        $this->assertContains('uncategorized', $signatures);
+    }
 }

--- a/tests/Feature/Widgets/ProductStatsTest.php
+++ b/tests/Feature/Widgets/ProductStatsTest.php
@@ -367,4 +367,25 @@ class ProductStatsTest extends TestCase
 
         $this->assertTrue($data['groups'][0]['collapsed']);
     }
+
+    public function test_same_tag_set_produces_one_group_regardless_of_attach_order(): void
+    {
+        $alpha = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);
+        $beta = Tag::factory()->create(['name' => 'Beta', 'weight' => 10, 'user_id' => $this->user->id]);
+
+        $first = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 1, 'date' => now()->toDateString()]]]);
+        $first->tags()->attach([$alpha->id, $beta->id]);
+
+        // Same tag set, attached in the opposite order.
+        $second = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 2, 'date' => now()->toDateString()]]]);
+        $second->tags()->attach([$beta->id, $alpha->id]);
+
+        $groups = ProductStats::getProductsGrouped();
+
+        // One canonical group containing both products, with a stable heading.
+        $this->assertCount(1, $groups);
+        $group = array_values($groups)[0];
+        $this->assertSame('Alpha, Beta', $group['heading']);
+        $this->assertCount(2, $group['products']);
+    }
 }

--- a/tests/Feature/Widgets/ProductStatsTest.php
+++ b/tests/Feature/Widgets/ProductStatsTest.php
@@ -334,4 +334,37 @@ class ProductStatsTest extends TestCase
         $this->assertContains(min($tagA->id, $tagB->id).'-'.max($tagA->id, $tagB->id), $signatures);
         $this->assertContains('uncategorized', $signatures);
     }
+
+    public function test_view_data_orders_categories_by_user_preference(): void
+    {
+        $tagA = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);
+        $tagB = Tag::factory()->create(['name' => 'Beta', 'weight' => 20, 'user_id' => $this->user->id]);
+
+        $pa = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 1, 'date' => now()->toDateString(), 'history' => []]]]);
+        $pa->tags()->attach($tagA);
+        $pb = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 1, 'date' => now()->toDateString(), 'history' => []]]]);
+        $pb->tags()->attach($tagB);
+
+        // User prefers Beta before Alpha (opposite of tag weight).
+        (new \App\Services\Dashboard\DashboardLayoutService($this->user))
+            ->setCategoryOrder([(string) $tagB->id, (string) $tagA->id]);
+
+        $data = \Livewire\Livewire::test(ProductStats::class)->instance()->getViewData();
+
+        $headings = array_column($data['groups'], 'heading');
+        $this->assertSame(['Beta', 'Alpha'], $headings);
+    }
+
+    public function test_view_data_marks_collapsed_categories(): void
+    {
+        $tag = Tag::factory()->create(['name' => 'Alpha', 'weight' => 10, 'user_id' => $this->user->id]);
+        $p = Product::factory()->create(['user_id' => $this->user->id, 'favourite' => true, 'status' => 'p', 'price_cache' => [['price' => 1, 'date' => now()->toDateString(), 'history' => []]]]);
+        $p->tags()->attach($tag);
+
+        (new \App\Services\Dashboard\DashboardLayoutService($this->user))->toggleCategoryCollapse((string) $tag->id);
+
+        $data = \Livewire\Livewire::test(ProductStats::class)->instance()->getViewData();
+
+        $this->assertTrue($data['groups'][0]['collapsed']);
+    }
 }


### PR DESCRIPTION
## Overview

Overhauls the admin dashboard and adds two related product-management improvements.

## Dashboard customization

- **Smart sections** above your tag groups — *Summary stats*, *What's good to buy now*, *Recently dropped*, and *Needs attention* — each backed by dedicated data builders.
- **Customize** header action to show/hide those sections, persisted per user.
- **Drag & drop**: reorder tag groups, reorder products within a group, and drag a product between groups to re-tag it (drop on `Uncategorized` clears its tags). Order and collapse state are saved per user.
- Refined drag handles: product **image** drags a card; the tag-group handle is the heading **icon + name** only, leaving the collapse chevron and empty space non-draggable.
- Deal-score verdict rendered as a card badge; next-check countdown hidden on cards.

## Product create form

URL is now the first field; existing-product, a new **Tags** select, price factor and create-store sit in a 2-column group. Tags chosen at create time attach to new products and **merge** onto existing ones.

## Edit a URL in place, retaining history

`Url::changeUrl()` re-points a URL on the same record, re-resolves the store from the new domain, and appends a fresh price while **keeping existing price history**. Both the product-edit and product-show widgets now expose an editable URL field. Fails closed on unresolvable URLs.

## Docs

Documented dashboard customization in `docs/docs/tags.md` and `docs/docs/features.md`.

## Testing

Full suite green — 988 passed, 1 skipped. Pint + PHPStan clean.

https://claude.ai/code/session_01MAEjnKDVnpKxrp9rdh5rr6


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a customizable dashboard with show/hide sections, collapsible category groups, and drag-and-drop reordering and retagging.
  * Added tag selection during product creation (including inline tag creation).
  * Added a short “next check” countdown label and improved verdict-based product badges.

* **Bug Fixes**
  * URL edits now validate and re-resolve the destination store while preserving price history; failures show a clear error.
  * Missing price history now safely defaults instead of causing errors.
  * Product URL edits now update store/url consistently and keep related pricing data intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->