### PR TITLE
Modify Amazon USA store seeder for price and availability

### DIFF
--- a/database/seeders/Stores/usa.php
+++ b/database/seeders/Stores/usa.php
@@ -14,12 +14,22 @@ return [
                 'type' => 'selector',
             ],
             'price' => [
-                'value' => '.a-price > .a-offscreen',
+                'value' => '.apex-pricetopay-value > .a-offscreen',
                 'type' => 'selector',
             ],
             'image' => [
                 'value' => '~"hiRes":"(.+?)"~',
                 'type' => 'regex',
+            ],
+            'availability' => [
+                'type' => 'selector',
+                'value' => '#outOfStock',
+            ],
+        ],
+        'settings' => [
+            'locale_settings' => [
+                'locale' => 'en_US',
+                'currency' => 'USD',
             ],
         ],
     ],


### PR DESCRIPTION
Manually update Amazon US store config for price and availability. This may be wrong since I manually did this by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Amazon US store scraping so product prices are captured more reliably.
  * Added availability detection for out-of-stock items, helping keep product status more accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->