### PR TITLE
Fix search hydration crashes on bad HTML and empty domains

### DIFF
--- a/app/Models/Store.php
+++ b/app/Models/Store.php
@@ -126,9 +126,17 @@ class Store extends Model
      * Scopes.
      **************************************************/
 
-    public function scopeDomainFilter(Builder $query, string|array $domains): Builder
+    public function scopeDomainFilter(Builder $query, string|array|null $domains): Builder
     {
-        $domains = Arr::wrap($domains);
+        $domains = array_values(array_filter(
+            Arr::wrap($domains),
+            fn ($domain) => filled($domain)
+        ));
+
+        if ($domains === []) {
+            return $query->whereRaw('1 = 0');
+        }
+
         $first = array_shift($domains);
 
         return $query->where(function (Builder $subQuery) use ($first, $domains) {

--- a/app/Models/UrlResearch.php
+++ b/app/Models/UrlResearch.php
@@ -60,22 +60,25 @@ class UrlResearch extends Model
             return $query->whereRaw('1 = 0'); // Return no results
         }
 
-        $service = SearchService::new($searchQuery);
+        // Quiet: this scope only needs URLs, not a progress log in cache.
+        $service = SearchService::new($searchQuery)->setQuiet(true);
 
         // If a specific product source is provided, filter by it
         if ($productSource) {
             $service->setProductSource($productSource);
         }
 
-        $urls = $service
-            ->getProductSourceResults();
+        $builder = $service->getProductSourceResults();
 
         // Only call getRawResults if not filtering by specific source
         if (! $productSource) {
-            $urls = $urls->getRawResults();
+            $builder->getRawResults();
         }
 
-        $urls = $urls->getResults()->pluck('url');
+        $urls = $builder
+            ->filterResults()
+            ->getResults()
+            ->pluck('url');
 
         return $query->whereIn('url', $urls);
     }

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -221,6 +221,10 @@ class ScrapeUrl
     {
         $host = Uri::of($this->url)->host();
 
+        if (blank($host)) {
+            return null;
+        }
+
         return Store::query()->domainFilter($host)->oldest()->first();
     }
 

--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -345,10 +345,11 @@ class SearchService
                     } else {
                         $this->replaceLastLogEntry(__('No Price found ":title" (:domain)', $logArgs), ['icon' => Icons::Warning->value]);
                     }
-                } catch (Exception $e) {
+                } catch (Throwable $e) {
                     // Never put getTrace() into the search log cache — frames can contain
                     // Closures and will throw "Serialization of 'Closure' is not allowed",
-                    // aborting the job before setIsComplete() runs.
+                    // aborting the job before setIsComplete() runs. Catch Throwable so
+                    // TypeError and friends also stay per-result instead of killing the job.
                     logger()->warning('Search hydration failed', [
                         'url' => $result['url'],
                         'error' => $e->getMessage(),
@@ -411,7 +412,7 @@ class SearchService
             }
 
             UrlResearch::updateOrCreate(['url' => $result['url']], $payload);
-        } catch (Exception $e) {
+        } catch (Throwable $e) {
             // Persistence failures must not abort the rest of the search job.
             logger()->warning('Failed to persist url research', [
                 'url' => $result['url'],
@@ -422,6 +423,9 @@ class SearchService
 
     /**
      * Normalize scraped HTML to UTF-8 so utf8mb4 MySQL / cache stores do not reject it.
+     *
+     * Prefer repairing invalid UTF-8 sequences over assuming Windows-1252, so a
+     * mostly-UTF-8 body with a few bad bytes is not wholesale re-decoded.
      */
     protected function sanitizeUtf8(?string $value): ?string
     {
@@ -433,12 +437,17 @@ class SearchService
             return $value;
         }
 
+        $repaired = @iconv('UTF-8', 'UTF-8//IGNORE', $value);
+        if (is_string($repaired) && mb_check_encoding($repaired, 'UTF-8') && strlen($repaired) >= (int) (strlen($value) * 0.9)) {
+            return $repaired;
+        }
+
         $converted = @mb_convert_encoding($value, 'UTF-8', 'Windows-1252');
         if ($converted !== false && mb_check_encoding($converted, 'UTF-8')) {
             return $converted;
         }
 
-        return iconv('UTF-8', 'UTF-8//IGNORE', $value) ?: '';
+        return is_string($repaired) && mb_check_encoding($repaired, 'UTF-8') ? $repaired : '';
     }
 
     public static function getSettings(): array
@@ -535,6 +544,10 @@ class SearchService
 
     public function replaceLastLogEntry(string $message, array $data = []): self
     {
+        if ($this->quiet) {
+            return $this;
+        }
+
         $cache = Cache::get($this->getLogKey(), []);
 
         if (! empty($cache)) {

--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -37,6 +37,8 @@ class SearchService
 
     protected bool $useLaravelLog = false;
 
+    protected bool $quiet = false;
+
     protected array $ignoredExtensions = ['pdf', 'doc', 'xls', 'ppt', 'jpg', 'png', 'jpeg'];
 
     public function __construct(?string $query = null)
@@ -292,8 +294,14 @@ class SearchService
     {
         $this->log('Adding stores to search results');
 
-        $domains = $this->results->pluck('domain')->toArray();
-        $stores = Store::query()->select('id', 'domains')->domainFilter($domains)->get();
+        $domains = array_values(array_filter(
+            $this->results->pluck('domain')->all(),
+            fn ($domain) => filled($domain)
+        ));
+
+        $stores = $domains === []
+            ? collect()
+            : Store::query()->select('id', 'domains')->domainFilter($domains)->get();
 
         $this->results = $this->results
             ->map(function ($result) use ($stores) {
@@ -338,8 +346,18 @@ class SearchService
                         $this->replaceLastLogEntry(__('No Price found ":title" (:domain)', $logArgs), ['icon' => Icons::Warning->value]);
                     }
                 } catch (Exception $e) {
-                    $trace = $e->getTrace();
-                    $this->log(__('Failed for ":title": :error', array_merge($logArgs, ['error' => $e->getMessage()])), ['subtitle' => $result['url'], 'trace' => array_splice($trace, 0, 5)]);
+                    // Never put getTrace() into the search log cache — frames can contain
+                    // Closures and will throw "Serialization of 'Closure' is not allowed",
+                    // aborting the job before setIsComplete() runs.
+                    logger()->warning('Search hydration failed', [
+                        'url' => $result['url'],
+                        'error' => $e->getMessage(),
+                        'trace' => $e->getTraceAsString(),
+                    ]);
+                    $this->log(__('Failed for ":title": :error', array_merge($logArgs, ['error' => $e->getMessage()])), [
+                        'subtitle' => $result['url'],
+                        'icon' => Icons::Warning->value,
+                    ]);
                 }
 
                 $result['execution_time'] = (microtime(true) - $timeStart);
@@ -383,12 +401,44 @@ class SearchService
 
     protected function persistUrlResearchResult(array $result): void
     {
-        UrlResearch::updateOrCreate(
-            ['url' => $result['url']],
-            collect($result)->only([
+        try {
+            $payload = collect($result)->only([
                 'html', 'title', 'image', 'price', 'store_id', 'strategies', 'execution_time',
-            ])->all()
-        );
+            ])->all();
+
+            if (! empty($payload['html'])) {
+                $payload['html'] = $this->sanitizeUtf8($payload['html']);
+            }
+
+            UrlResearch::updateOrCreate(['url' => $result['url']], $payload);
+        } catch (Exception $e) {
+            // Persistence failures must not abort the rest of the search job.
+            logger()->warning('Failed to persist url research', [
+                'url' => $result['url'],
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Normalize scraped HTML to UTF-8 so utf8mb4 MySQL / cache stores do not reject it.
+     */
+    protected function sanitizeUtf8(?string $value): ?string
+    {
+        if ($value === null || $value === '') {
+            return $value;
+        }
+
+        if (mb_check_encoding($value, 'UTF-8')) {
+            return $value;
+        }
+
+        $converted = @mb_convert_encoding($value, 'UTF-8', 'Windows-1252');
+        if ($converted !== false && mb_check_encoding($converted, 'UTF-8')) {
+            return $converted;
+        }
+
+        return iconv('UTF-8', 'UTF-8//IGNORE', $value) ?: '';
     }
 
     public static function getSettings(): array
@@ -462,6 +512,10 @@ class SearchService
 
     public function log(string $message, array $data = []): self
     {
+        if ($this->quiet) {
+            return $this;
+        }
+
         $cache = Cache::get($this->getLogKey(), []);
 
         $cache[] = [
@@ -500,6 +554,13 @@ class SearchService
         return $this;
     }
 
+    public function setQuiet(bool $quiet): self
+    {
+        $this->quiet = $quiet;
+
+        return $this;
+    }
+
     public function getLog(?string $searchQuery = null): array
     {
         if ($searchQuery) {
@@ -511,6 +572,10 @@ class SearchService
 
     public function logReset(): self
     {
+        if ($this->quiet) {
+            return $this;
+        }
+
         Cache::delete($this->getLogKey());
 
         return $this;

--- a/app/Services/SearchService.php
+++ b/app/Services/SearchService.php
@@ -424,8 +424,9 @@ class SearchService
     /**
      * Normalize scraped HTML to UTF-8 so utf8mb4 MySQL / cache stores do not reject it.
      *
-     * Prefer repairing invalid UTF-8 sequences over assuming Windows-1252, so a
-     * mostly-UTF-8 body with a few bad bytes is not wholesale re-decoded.
+     * Prefer Windows-1252 conversion only for single-byte legacy content. Bodies
+     * that already contain UTF-8 multi-byte sequences are repaired in place so
+     * mostly-UTF-8 pages are not wholesale re-decoded as Windows-1252.
      */
     protected function sanitizeUtf8(?string $value): ?string
     {
@@ -437,15 +438,14 @@ class SearchService
             return $value;
         }
 
-        $repaired = @iconv('UTF-8', 'UTF-8//IGNORE', $value);
-        if (is_string($repaired) && mb_check_encoding($repaired, 'UTF-8') && strlen($repaired) >= (int) (strlen($value) * 0.9)) {
-            return $repaired;
+        if (! preg_match('/[\xC2-\xF4][\x80-\xBF]/', $value)) {
+            $converted = @mb_convert_encoding($value, 'UTF-8', 'Windows-1252');
+            if ($converted !== false && mb_check_encoding($converted, 'UTF-8')) {
+                return $converted;
+            }
         }
 
-        $converted = @mb_convert_encoding($value, 'UTF-8', 'Windows-1252');
-        if ($converted !== false && mb_check_encoding($converted, 'UTF-8')) {
-            return $converted;
-        }
+        $repaired = @iconv('UTF-8', 'UTF-8//IGNORE', $value);
 
         return is_string($repaired) && mb_check_encoding($repaired, 'UTF-8') ? $repaired : '';
     }

--- a/tests/Feature/Models/StoreTest.php
+++ b/tests/Feature/Models/StoreTest.php
@@ -44,6 +44,17 @@ class StoreTest extends TestCase
         $this->assertEquals('', $store->domains_html);
     }
 
+    public function test_domain_filter_accepts_null_and_empty_domains_without_error()
+    {
+        Store::factory()->create(['domains' => [['domain' => 'example.com']]]);
+
+        $this->assertSame(0, Store::query()->domainFilter(null)->count());
+        $this->assertSame(0, Store::query()->domainFilter([])->count());
+        $this->assertSame(0, Store::query()->domainFilter(['', null])->count());
+        $this->assertSame(1, Store::query()->domainFilter('example.com')->count());
+        $this->assertSame(0, Store::query()->domainFilter('missing.example')->count());
+    }
+
     public function test_scraper_service_returns_default_value()
     {
         $store = Store::factory()->create(['settings' => []]);

--- a/tests/Feature/Services/SearchServiceTest.php
+++ b/tests/Feature/Services/SearchServiceTest.php
@@ -197,6 +197,84 @@ class SearchServiceTest extends TestCase
         $this->assertSame(Icons::Success->value, data_get($priceEntry, 'data.icon'));
     }
 
+    public function test_hydration_failures_do_not_serialize_exception_traces_into_the_search_log()
+    {
+        $service = new class('laptop') extends SearchService
+        {
+            protected function getHydratedResultData(array $result): array
+            {
+                throw new Exception('scrape failed', previous: new Exception('root cause'));
+            }
+        };
+
+        $service->results = collect([
+            ['title' => 'Broken', 'url' => 'https://example.com/broken', 'domain' => 'example.com'],
+        ]);
+
+        $service->hydrateWithScrapedData();
+
+        $failed = collect($service->getLog())
+            ->first(fn ($entry) => str_contains($entry['message'], 'Failed for'));
+
+        $this->assertNotNull($failed);
+        $this->assertArrayNotHasKey('trace', $failed['data'] ?? []);
+        $this->assertSame(Icons::Warning->value, data_get($failed, 'data.icon'));
+        $this->assertSame(1, UrlResearch::query()->count());
+    }
+
+    public function test_non_utf8_html_is_sanitized_before_url_research_persist()
+    {
+        $service = new class('laptop') extends SearchService
+        {
+            protected function getHydratedResultData(array $result): array
+            {
+                // Windows-1252 curly quote (0x94) — invalid as UTF-8.
+                return [
+                    'price' => 12.0,
+                    'image' => null,
+                    'strategies' => [],
+                    'is_product_page' => null,
+                    'html' => "<html><body>smart\x94quote</body></html>",
+                ];
+            }
+        };
+
+        $service->results = collect([
+            ['title' => 'Legacy', 'url' => 'https://example.com/legacy', 'domain' => 'example.com'],
+        ]);
+
+        $service->hydrateWithScrapedData();
+
+        $research = UrlResearch::query()->first();
+        $this->assertNotNull($research);
+        $this->assertTrue(mb_check_encoding((string) $research->html, 'UTF-8'));
+        $this->assertStringNotContainsString("\x94", (string) $research->html);
+    }
+
+    public function test_add_stores_tolerates_null_domains()
+    {
+        $service = new SearchService('laptop');
+        $service->results = collect([
+            ['title' => 'No host', 'url' => 'not-a-url', 'domain' => null],
+            ['title' => 'Blank host', 'url' => 'https:///', 'domain' => ''],
+        ]);
+
+        $method = new \ReflectionMethod(SearchService::class, 'addStores');
+        $method->setAccessible(true);
+        $method->invoke($service);
+
+        $this->assertNull($service->results[0]['store_id']);
+        $this->assertNull($service->results[1]['store_id']);
+    }
+
+    public function test_quiet_mode_skips_search_log_writes()
+    {
+        $service = SearchService::new('laptop')->setQuiet(true);
+        $service->log('should not appear');
+
+        $this->assertSame([], $service->setQuiet(false)->getLog());
+    }
+
     public function test_product_source_count_is_interpolated_in_the_log()
     {
         $service = new SearchService('laptop');

--- a/tests/Feature/Services/SearchServiceTest.php
+++ b/tests/Feature/Services/SearchServiceTest.php
@@ -249,6 +249,7 @@ class SearchServiceTest extends TestCase
         $this->assertNotNull($research);
         $this->assertTrue(mb_check_encoding((string) $research->html, 'UTF-8'));
         $this->assertStringNotContainsString("\x94", (string) $research->html);
+        $this->assertStringContainsString("\u{201D}", (string) $research->html);
     }
 
     public function test_add_stores_tolerates_null_domains()

--- a/tests/Feature/Services/SearchServiceTest.php
+++ b/tests/Feature/Services/SearchServiceTest.php
@@ -275,6 +275,19 @@ class SearchServiceTest extends TestCase
         $this->assertSame([], $service->setQuiet(false)->getLog());
     }
 
+    public function test_quiet_mode_does_not_pop_existing_log_entries()
+    {
+        $service = SearchService::new('laptop');
+        $service->log('live progress');
+
+        $before = $service->getLog();
+        $this->assertCount(1, $before);
+
+        $service->setQuiet(true)->replaceLastLogEntry('should not replace');
+
+        $this->assertSame($before, $service->setQuiet(false)->getLog());
+    }
+
     public function test_product_source_count_is_interpolated_in_the_log()
     {
         $service = new SearchService('laptop');


### PR DESCRIPTION
## Summary
- Stop aborting search jobs when a single URL fails hydration (safe error logging; no Closure stack frames in cache)
- Sanitize non-UTF-8 HTML before persisting `url_research`
- Harden `Store::domainFilter` / empty domains so SearchXNG hits without a host cannot TypeError the job
- Quiet mode for research lookups so they do not overwrite the live search progress log

## Why
A single legacy page (invalid UTF-8) could:
1. fail MySQL `utf8mb4` persistence, then
2. crash again while logging `$e->getTrace()` (Closures are not serializable),

leaving the UI stuck on “Analyzing …” forever because `complete` was never set.

Empty/null domains from some search hits caused a separate hard crash in `scopeDomainFilter`.

## Related
Companion package PR (recommended together): jez500/Web-scraper-for-Laravel — sanitize UTF-8 at scrape time.

## Test plan
- [x] Feature tests for hydration failure logging, UTF-8 sanitize on persist, null domains, quiet mode, domainFilter
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved store domain filtering to safely handle `null` and empty/invalid domain inputs, returning no matches instead of erroring.
  - Prevented store lookups when a URL host is blank.
  - Refined search URL fetching to consistently build, filter, and return results.
  - Hardened search hydration/persistence so failures don’t stop the search and logs are cleaner.
  - Sanitized scraped HTML to ensure saved content is valid UTF-8.
- **New Features**
  - Added “quiet” mode to suppress search-log writes.
- **Tests**
  - Added coverage for domain filtering edge cases, hydration/persistence failure behavior, UTF-8 sanitization, store assignment tolerance, and quiet-mode logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->