### PR TITLE
Fix search progress UI stuck after jobs complete

### DIFF
--- a/app/Filament/Resources/ProductResource/Widgets/CreateViaSearchForm.php
+++ b/app/Filament/Resources/ProductResource/Widgets/CreateViaSearchForm.php
@@ -140,9 +140,6 @@ class CreateViaSearchForm extends Widget implements HasForms
             return;
         }
 
-        // Avoid empty log.
-        $this->progressLog[] = ['message' => __('Preparing to search'), 'timestamp' => now()];
-
         $service = SearchService::new($this->searchQuery);
 
         if ($inProgress = $service->getInProgress()) {
@@ -160,10 +157,13 @@ class CreateViaSearchForm extends Widget implements HasForms
         }
 
         if ($this->isComplete || $this->inProgress) {
-            $this->refreshProgress();
+            $this->syncProgressFromService();
 
             return;
         }
+
+        // Avoid empty log.
+        $this->progressLog[] = ['message' => __('Preparing to search'), 'timestamp' => now()];
 
         $this->inProgress = now()->toDateTimeString();
         $this->progressLog[] = ['message' => __('Dispatching search job for ":query"', ['query' => $this->searchQuery]), 'timestamp' => now()];
@@ -182,15 +182,34 @@ class CreateViaSearchForm extends Widget implements HasForms
      */
     public function refreshProgress(): void
     {
+        if ($this->isComplete && ! $this->inProgress) {
+            return;
+        }
+
+        $this->syncProgressFromService();
+    }
+
+    protected function syncProgressFromService(): void
+    {
         $searchQuery = $this->searchQuery ?? $this->getSearchKeywordFromForm();
 
-        if ($searchQuery && ! $this->isComplete) {
-            $this->progressLog[] = ['message' => __('Refreshing progress for ":query"', ['query' => $searchQuery]), 'timestamp' => now()];
+        if (! $searchQuery) {
+            return;
+        }
 
-            $service = SearchService::new($searchQuery);
-            $this->progressLog = $service->getLog();
-            $this->inProgress = $service->getInProgress();
-            $this->isComplete = $service->getIsComplete();
+        $service = SearchService::new($searchQuery);
+        $log = $service->getLog();
+
+        if (! empty($log)) {
+            $this->progressLog = $log;
+        }
+
+        if ($inProgress = $service->getInProgress()) {
+            $this->inProgress = $inProgress;
+        }
+
+        if ($isComplete = $service->getIsComplete()) {
+            $this->isComplete = $isComplete;
         }
     }
 

--- a/app/Filament/Resources/ProductResource/Widgets/CreateViaSearchForm.php
+++ b/app/Filament/Resources/ProductResource/Widgets/CreateViaSearchForm.php
@@ -204,13 +204,8 @@ class CreateViaSearchForm extends Widget implements HasForms
             $this->progressLog = $log;
         }
 
-        if ($inProgress = $service->getInProgress()) {
-            $this->inProgress = $inProgress;
-        }
-
-        if ($isComplete = $service->getIsComplete()) {
-            $this->isComplete = $isComplete;
-        }
+        $this->inProgress = $service->getInProgress() ?: false;
+        $this->isComplete = $service->getIsComplete() ?: false;
     }
 
     protected function getSearchKeywordFromForm(): string

--- a/app/Filament/Resources/ProductSourceResource/Pages/SearchProductSource.php
+++ b/app/Filament/Resources/ProductSourceResource/Pages/SearchProductSource.php
@@ -175,13 +175,8 @@ class SearchProductSource extends EditRecord
             $this->progressLog = $log;
         }
 
-        if ($inProgress = $service->getInProgress()) {
-            $this->inProgress = $inProgress;
-        }
-
-        if ($isComplete = $service->getIsComplete()) {
-            $this->isComplete = $isComplete;
-        }
+        $this->inProgress = $service->getInProgress() ?: false;
+        $this->isComplete = $service->getIsComplete() ?: false;
     }
 
     public function getFormActions(): array

--- a/app/Filament/Resources/ProductSourceResource/Pages/SearchProductSource.php
+++ b/app/Filament/Resources/ProductSourceResource/Pages/SearchProductSource.php
@@ -112,11 +112,6 @@ class SearchProductSource extends EditRecord
 
         $this->showLog = ! empty($this->searchQuery);
 
-        // Avoid empty log
-        if (empty($this->progressLog)) {
-            $this->progressLog[] = ['message' => __('Preparing to search'), 'timestamp' => now()];
-        }
-
         $source = $this->getRecord();
 
         $service = SearchService::new($this->searchQuery)->setProductSource($source);
@@ -136,9 +131,14 @@ class SearchProductSource extends EditRecord
         }
 
         if ($this->isComplete || $this->inProgress) {
-            $this->refreshProgress();
+            $this->syncProgressFromService();
 
             return;
+        }
+
+        // Avoid empty log
+        if (empty($this->progressLog)) {
+            $this->progressLog[] = ['message' => __('Preparing to search'), 'timestamp' => now()];
         }
 
         $this->inProgress = now()->toDateTimeString();
@@ -155,13 +155,32 @@ class SearchProductSource extends EditRecord
 
     public function refreshProgress(): void
     {
-        if ($this->searchQuery && ! $this->isComplete) {
-            $this->progressLog[] = ['message' => __('Refreshing progress for ":query"', ['query' => $this->searchQuery]), 'timestamp' => now()];
+        if ($this->isComplete && ! $this->inProgress) {
+            return;
+        }
 
-            $service = SearchService::new($this->searchQuery)->setProductSource($this->getRecord());
-            $this->progressLog = $service->getLog();
-            $this->inProgress = $service->getInProgress();
-            $this->isComplete = $service->getIsComplete();
+        $this->syncProgressFromService();
+    }
+
+    protected function syncProgressFromService(): void
+    {
+        if (! $this->searchQuery) {
+            return;
+        }
+
+        $service = SearchService::new($this->searchQuery)->setProductSource($this->getRecord());
+        $log = $service->getLog();
+
+        if (! empty($log)) {
+            $this->progressLog = $log;
+        }
+
+        if ($inProgress = $service->getInProgress()) {
+            $this->inProgress = $inProgress;
+        }
+
+        if ($isComplete = $service->getIsComplete()) {
+            $this->isComplete = $isComplete;
         }
     }
 

--- a/resources/views/filament/resources/product-resource/widgets/create-via-search.blade.php
+++ b/resources/views/filament/resources/product-resource/widgets/create-via-search.blade.php
@@ -21,8 +21,8 @@
     <div class="min-h-96">
 
         @if ($showLog)
-            <div wire:poll.visible="refreshProgress" x-init="window.document.getElementById('searchHeading')?.scrollIntoView({behavior: 'smooth'})">
-                <livewire:search-log :messages="$progressLog" :complete="$isComplete" wire:key="{{ $searchLogKey }}" />
+            <div @unless($isComplete) wire:poll.visible.2s="refreshProgress" @endunless x-init="window.document.getElementById('searchHeading')?.scrollIntoView({behavior: 'smooth'})">
+                <livewire:search-log :messages="$progressLog" :complete="(bool) $isComplete" wire:key="{{ $searchLogKey }}" />
             </div>
         @endif
 

--- a/resources/views/filament/resources/product-source-resource/pages/search-product-source.blade.php
+++ b/resources/views/filament/resources/product-source-resource/pages/search-product-source.blade.php
@@ -18,8 +18,8 @@
 
         {{-- Progress Log --}}
         @if ($showLog)
-            <div wire:poll.visible="refreshProgress">
-                <livewire:search-log :messages="$progressLog" :complete="$isComplete" wire:key="{{ $searchLogKey }}" />
+            <div @unless($isComplete) wire:poll.visible.2s="refreshProgress" @endunless>
+                <livewire:search-log :messages="$progressLog" :complete="(bool) $isComplete" wire:key="{{ $searchLogKey }}" />
             </div>
         @endif
     </div>


### PR DESCRIPTION
## Summary
- Sync search progress from the service cache when reopening an in-progress or completed search
- Stop Livewire polling once the search is complete
- Cast `$isComplete` so the search-log completion state renders correctly

## Why
Revisiting a finished search skipped `refreshProgress()` because `isComplete` was already set, so the UI kept showing only the local “Preparing to search” line even though the job had finished.

## Test plan
- [ ] Manually: start a product search, leave the page, return after completion — log and results should appear without a stuck spinner
- [ ] Manually: while a search is running, confirm progress still polls about every 2s
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search progress synchronization for both completed and in-progress searches.
  * Prevented unnecessary progress refresh behavior once a search is complete.
  * Updated progress log handling to reflect current service state without redundant entries.
* **Performance**
  * Reduced polling: progress updates now refresh every 2 seconds only while the search is incomplete and visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->