### PR TITLE
Ignore soft-404 pages when scraping product prices

### DIFF
--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -208,6 +208,7 @@ class ScrapeUrl
 
             $output['body'] = $page->getBody();
             $output['errors'] = $scraper->getErrors();
+            $output = $this->applyNotFoundPageGuards($output);
         } catch (Exception $e) {
             $this->errorLog('Error scraping URL', [
                 'error' => $e->getMessage(),
@@ -215,6 +216,43 @@ class ScrapeUrl
         }
 
         return $output;
+    }
+
+    /**
+     * Soft 404s still return HTML with a title and often an unrelated dollar
+     * amount in banners (e.g. "Orders Over $899!"). Treat those pages as
+     * discontinued and drop any scraped price so shipping thresholds are never
+     * stored as product prices.
+     */
+    protected function applyNotFoundPageGuards(array $output): array
+    {
+        if (! $this->looksLikeNotFoundPage(
+            (string) ($output['title'] ?? ''),
+            (string) ($output['body'] ?? ''),
+        )) {
+            return $output;
+        }
+
+        $output['price'] = null;
+        $output['availability'] = 'https://schema.org/Discontinued';
+
+        return $output;
+    }
+
+    protected function looksLikeNotFoundPage(string $title, string $body): bool
+    {
+        if ($title !== '' && preg_match('/\b404\b|not\s+found|page\s+(?:you\s+(?:were|are)\s+looking\s+for\s+)?(?:does\s+not\s+exist|not\s+found)/i', $title) === 1) {
+            return true;
+        }
+
+        if ($body === '') {
+            return false;
+        }
+
+        return preg_match(
+            '/\btemplate-404\b|data-page-type=["\']404["\']|"pageType"\s*:\s*"404"|rel=["\']canonical["\'][^>]*href=["\'][^"\']*\/404["\']|href=["\'][^"\']*\/404["\'][^>]*rel=["\']canonical["\']/i',
+            $body
+        ) === 1;
     }
 
     public function getStore(): ?Store

--- a/tests/Unit/Services/ScrapeUrlTest.php
+++ b/tests/Unit/Services/ScrapeUrlTest.php
@@ -241,4 +241,52 @@ class ScrapeUrlTest extends TestCase
         $this->assertEquals('49.99', $result['price']);
         $this->assertEquals('https://example.com/schema.jpg', $result['image']);
     }
+
+    public function test_soft_404_pages_drop_banner_prices_and_mark_discontinued()
+    {
+        $this->store->update([
+            'settings' => ['scraper_service' => 'http'],
+            'scrape_strategy' => [
+                'title' => ['type' => 'selector', 'value' => 'title'],
+                'price' => ['type' => 'regex', 'value' => '\$([0-9]+(?:\.[0-9]{2})?)'],
+                'image' => ['type' => 'selector', 'value' => 'img|src'],
+            ],
+        ]);
+
+        // Soft 404: real title/body markers, but a shipping-threshold dollar amount
+        // that a naive price regex would happily scrape.
+        Http::fake([
+            '*' => Http::response(<<<'HTML'
+<!DOCTYPE html>
+<html>
+<head>
+    <title>404 Not Found</title>
+    <link rel="canonical" href="https://example.com/404">
+</head>
+<body class="template-404">
+    <p>Orders Over $899!</p>
+    <p>Sorry, the page you were looking for does not exist.</p>
+</body>
+</html>
+HTML),
+        ]);
+
+        $result = ScrapeUrl::new(self::TEST_URL)->scrape();
+
+        $this->assertNull($result['price'] ?? null);
+        $this->assertSame('https://schema.org/Discontinued', $result['availability'] ?? null);
+    }
+
+    public function test_looks_like_not_found_page_detects_common_markers()
+    {
+        $scrapeUrl = ScrapeUrl::new(self::TEST_URL);
+        $method = new \ReflectionMethod(ScrapeUrl::class, 'looksLikeNotFoundPage');
+        $method->setAccessible(true);
+
+        $this->assertTrue($method->invoke($scrapeUrl, '404 Not Found', ''));
+        $this->assertTrue($method->invoke($scrapeUrl, 'Page not found', ''));
+        $this->assertTrue($method->invoke($scrapeUrl, 'Widget', '<body class="template-404"></body>'));
+        $this->assertTrue($method->invoke($scrapeUrl, 'Widget', '<html data-page-type="404"></html>'));
+        $this->assertFalse($method->invoke($scrapeUrl, 'Pellet Grill', '<body><p>$899 product</p></body>'));
+    }
 }

--- a/tests/Unit/Services/ScrapeUrlTest.php
+++ b/tests/Unit/Services/ScrapeUrlTest.php
@@ -287,6 +287,16 @@ HTML),
         $this->assertTrue($method->invoke($scrapeUrl, 'Page not found', ''));
         $this->assertTrue($method->invoke($scrapeUrl, 'Widget', '<body class="template-404"></body>'));
         $this->assertTrue($method->invoke($scrapeUrl, 'Widget', '<html data-page-type="404"></html>'));
+        $this->assertTrue($method->invoke(
+            $scrapeUrl,
+            'Widget',
+            '<link rel="canonical" href="https://example.com/404">'
+        ));
+        $this->assertTrue($method->invoke(
+            $scrapeUrl,
+            'Widget',
+            '<link href="https://example.com/404" rel="canonical">'
+        ));
         $this->assertFalse($method->invoke($scrapeUrl, 'Pellet Grill', '<body><p>$899 product</p></body>'));
     }
 }


### PR DESCRIPTION
## Summary
- Detect common soft-404 markers (title text, Shopify `template-404`, canonical `/404`, etc.)
- Clear any scraped price and set availability to `https://schema.org/Discontinued`

## Why
Soft 404 HTML still has a title and often a promotional banner with a dollar amount (e.g. “Orders Over $899!”). Naive price selectors then store that banner amount as the product price, which shows up as a false “deal.”

Related discussion: out-of-stock / unavailable URL handling (#166).

## Test plan
- [x] Unit tests for soft-404 detection and scrape behavior (banner price dropped)
- [ ] Manually: scrape a known soft-404 product URL with a banner dollar amount — price should be empty / discontinued
- [ ] CI green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved soft-404 detection by analyzing scraped page titles and HTML content for common not-found/discontinued markers.
  * For pages identified as unavailable, pricing values are no longer stored.
  * Marked such pages with `https://schema.org/Discontinued` to prevent misleading availability/threshold-based pricing.

* **Tests**
  * Added unit coverage for soft-404 behavior, including “banner/threshold” scenarios.
  * Added detection tests for multiple 404-like markers and non-matching content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->