### PR TITLE
feat: expose resolved store currency and locale on the API

### DIFF
--- a/app/Filament/Resources/StoreResource/Api/Handlers/PaginationHandler.php
+++ b/app/Filament/Resources/StoreResource/Api/Handlers/PaginationHandler.php
@@ -10,7 +10,9 @@ use App\Models\Url;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Support\Arr;
 use Rupadana\ApiService\Http\Handlers;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -109,6 +111,23 @@ class PaginationHandler extends Handlers
     }
 
     /**
+     * The sparse fieldset requested for stores, if any. Spatie accepts the comma-separated
+     * form (fields[stores]=id,name) and clients sometimes send the array form, so both are
+     * flattened to a plain list. An empty list means no sparse fieldset was requested.
+     *
+     * @return array<int, string>
+     */
+    protected function requestedStoreFields(): array
+    {
+        return collect(Arr::wrap(request()->input('fields.stores')))
+            ->flatMap(fn ($value): array => explode(',', (string) $value))
+            ->map(fn (string $field): string => trim($field))
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    /**
      * List of Stores
      *
      * @return AnonymousResourceCollection
@@ -137,13 +156,23 @@ class PaginationHandler extends Handlers
         // app-level fallback instead of the store's override. Force the column into the
         // select in that case. Only when fields were requested: addSelect() on a query with
         // no select clause would narrow `select *` down to this one column.
-        if (filled(request()->input('fields.stores'))) {
+        $requestedFields = $this->requestedStoreFields();
+
+        if ($requestedFields !== []) {
             $query->addSelect('stores.settings');
         }
 
         $query = $query
             ->paginate($this->getPerPage())
             ->appends(request()->query());
+
+        // `settings` was selected to resolve those accessors, not because the client asked
+        // for it. Hide it again so a sparse fieldset returns only the requested fields —
+        // it carries per-store scraper configuration and has no business leaking into a
+        // response that asked for `id,name`.
+        if ($requestedFields !== [] && ! in_array('settings', $requestedFields, true)) {
+            $query->getCollection()->each(fn (Model $store) => $store->makeHidden('settings'));
+        }
 
         return StoreTransformer::collection($query);
     }

--- a/app/Filament/Resources/StoreResource/Api/Handlers/PaginationHandler.php
+++ b/app/Filament/Resources/StoreResource/Api/Handlers/PaginationHandler.php
@@ -128,7 +128,20 @@ class PaginationHandler extends Handlers
             ->allowedFields($this->getAllowedFields())
             ->allowedSorts($this->getAllowedSorts())
             ->allowedFilters($this->getAllowedFilters())
-            ->allowedIncludes($this->getAllowedIncludes())
+            ->allowedIncludes($this->getAllowedIncludes());
+
+        // StoreTransformer exposes `currency` and `locale`, which are accessors reading from
+        // `settings`. They are deliberately absent from getAllowedFields() (selecting a
+        // non-existent column would blow up), but a sparse fieldset that omits `settings`
+        // would leave the accessors reading a missing attribute and silently reporting the
+        // app-level fallback instead of the store's override. Force the column into the
+        // select in that case. Only when fields were requested: addSelect() on a query with
+        // no select clause would narrow `select *` down to this one column.
+        if (filled(request()->input('fields.stores'))) {
+            $query->addSelect('stores.settings');
+        }
+
+        $query = $query
             ->paginate($this->getPerPage())
             ->appends(request()->query());
 

--- a/app/Filament/Resources/StoreResource/Api/Transformers/StoreTransformer.php
+++ b/app/Filament/Resources/StoreResource/Api/Transformers/StoreTransformer.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\ProductResource\Api\Transformers\ProductTransformer;
 use App\Http\Resources\UrlResource;
 use App\Http\Resources\UserResource;
 use App\Models\Store;
+use App\Services\Helpers\LocaleHelper;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -26,6 +27,14 @@ class StoreTransformer extends JsonResource
     public function toArray($request)
     {
         $data = $this->resource->toArray();
+
+        // Resolved accessor values (ISO 4217 code + BCP-47 tag) rather than the raw
+        // `settings.locale_settings` blob, which is absent on most stores. Both accessors read
+        // from `settings`, so PaginationHandler forces that column into any sparse-fieldset
+        // select — without it they would silently report the app-level fallback instead of
+        // this store's override.
+        $data['currency'] = $this->resource->currency;
+        $data['locale'] = LocaleHelper::toBcp47($this->resource->locale);
 
         // Include relationships if they are loaded
         if ($this->resource->relationLoaded('user')) {

--- a/app/Filament/Resources/StoreResource/Api/Transformers/StoreTransformer.php
+++ b/app/Filament/Resources/StoreResource/Api/Transformers/StoreTransformer.php
@@ -6,6 +6,7 @@ use App\Filament\Resources\ProductResource\Api\Transformers\ProductTransformer;
 use App\Http\Resources\UrlResource;
 use App\Http\Resources\UserResource;
 use App\Models\Store;
+use App\Services\Helpers\CurrencyHelper;
 use App\Services\Helpers\LocaleHelper;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -33,8 +34,13 @@ class StoreTransformer extends JsonResource
         // from `settings`, so PaginationHandler forces that column into any sparse-fieldset
         // select — without it they would silently report the app-level fallback instead of
         // this store's override.
-        $data['currency'] = $this->resource->currency;
-        $data['locale'] = LocaleHelper::toBcp47($this->resource->locale);
+        //
+        // `?:` covers a store whose locale_settings hold an explicit null/empty value: the
+        // accessors use data_get(), which only falls back when the key is absent and returns
+        // null/'' as-is when it is present but empty. Without this, clients would receive
+        // `currency: null` and `locale: ""`, which Intl.NumberFormat rejects.
+        $data['currency'] = $this->resource->currency ?: CurrencyHelper::getCurrency();
+        $data['locale'] = LocaleHelper::toBcp47($this->resource->locale ?: CurrencyHelper::getLocale());
 
         // Include relationships if they are loaded
         if ($this->resource->relationLoaded('user')) {

--- a/app/Http/Resources/MetaExtractionResource.php
+++ b/app/Http/Resources/MetaExtractionResource.php
@@ -2,6 +2,9 @@
 
 namespace App\Http\Resources;
 
+use App\Models\Store;
+use App\Services\Helpers\CurrencyHelper;
+use App\Services\Helpers\LocaleHelper;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -18,10 +21,17 @@ class MetaExtractionResource extends JsonResource
     public function toArray(Request $request): array
     {
         $store = data_get($this->resource, 'store');
+        $store = $store instanceof Store ? $store : null;
 
         return [
             'title' => data_get($this->resource, 'title'),
             'price' => data_get($this->resource, 'price'),
+            // Sit alongside `price` so a client never has to reach into `store` to format it;
+            // `store` is `{}` when none could be resolved, hence the app-level fallback here.
+            // `?:` also covers a store whose locale_settings hold an explicit null/empty value,
+            // which data_get() returns as-is rather than falling back to its default.
+            'currency' => $store?->currency ?: CurrencyHelper::getCurrency(),
+            'locale' => LocaleHelper::toBcp47($store?->locale ?: CurrencyHelper::getLocale()),
             'image' => data_get($this->resource, 'image'),
             'description' => data_get($this->resource, 'description'),
             'availability' => data_get($this->resource, 'availability'),

--- a/app/Http/Resources/StoreResource.php
+++ b/app/Http/Resources/StoreResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use App\Models\Store;
+use App\Services\Helpers\LocaleHelper;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
@@ -28,6 +29,10 @@ class StoreResource extends JsonResource
             // The name differs intentionally to keep the public contract stable.
             'scrape_settings' => $this->resource->scrape_strategy,
             'settings' => $this->resource->settings,
+            // Resolved accessor values, not the raw `settings.locale_settings` blob, which is
+            // absent on most stores. ISO 4217 code and BCP-47 tag, so clients can format prices.
+            'currency' => $this->resource->currency,
+            'locale' => LocaleHelper::toBcp47($this->resource->locale),
         ];
     }
 }

--- a/app/Http/Resources/StoreResource.php
+++ b/app/Http/Resources/StoreResource.php
@@ -3,6 +3,7 @@
 namespace App\Http\Resources;
 
 use App\Models\Store;
+use App\Services\Helpers\CurrencyHelper;
 use App\Services\Helpers\LocaleHelper;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
@@ -31,8 +32,10 @@ class StoreResource extends JsonResource
             'settings' => $this->resource->settings,
             // Resolved accessor values, not the raw `settings.locale_settings` blob, which is
             // absent on most stores. ISO 4217 code and BCP-47 tag, so clients can format prices.
-            'currency' => $this->resource->currency,
-            'locale' => LocaleHelper::toBcp47($this->resource->locale),
+            // `?:` covers locale_settings holding an explicit null/empty value, which the
+            // data_get() in the accessors returns as-is rather than falling back.
+            'currency' => $this->resource->currency ?: CurrencyHelper::getCurrency(),
+            'locale' => LocaleHelper::toBcp47($this->resource->locale ?: CurrencyHelper::getLocale()),
         ];
     }
 }

--- a/app/Services/Helpers/LocaleHelper.php
+++ b/app/Services/Helpers/LocaleHelper.php
@@ -22,6 +22,16 @@ class LocaleHelper
         ];
     }
 
+    /**
+     * Convert an ICU locale ID (`en_AU`, as stored in settings) to a BCP-47 language
+     * tag (`en-AU`). API clients feed this straight into `Intl.NumberFormat`, which
+     * rejects the underscore form.
+     */
+    public static function toBcp47(?string $locale): string
+    {
+        return str_replace('_', '-', (string) $locale);
+    }
+
     public static function getAllLocalesAsOptions(): array
     {
         return collect(Locales::getNames())

--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -55,12 +55,19 @@ The response shape is:
   "data": {
     "title": "Example product",
     "price": 35.0,
+    "currency": "AUD",
+    "locale": "en-AU",
     "image": "https://example.com/image.jpg"
   }
 }
 ```
 
 The `price` field is normalized to a numeric value in both the store-backed and auto-create paths.
+
+`currency` (ISO 4217) and `locale` (BCP-47) tell a client how to format `price`. They come from
+the matched store's locale settings, falling back to the app-level defaults when no store could be
+resolved (in which case `store` is `{}`). Both are always present. The embedded `store` object
+carries the same two fields.
 
 ## Products
 
@@ -193,3 +200,13 @@ The response carries an `ETag` and `Cache-Control: private, max-age=86400`. Send
 Exact match on a host such as `www.Target.com.au` or `location.host` with a port. A
 leading `www.`, letter case and any port are ignored. Unlike `filter[domains]`, which is
 a partial match, this will not match a substring.
+
+### Currency & locale
+
+Every store in `GET /api/stores` and `GET /api/stores/{id}` carries a `currency` (ISO 4217, e.g.
+`"AUD"`) and a `locale` (BCP-47, e.g. `"en-AU"`). These are resolved values: a store's own
+`settings.locale_settings` if set, otherwise the app-level defaults from Settings. Reading the raw
+`settings` blob is not equivalent — most stores have no `locale_settings` key at all.
+
+Both are computed, not columns, so they cannot be named in `fields[stores]`. They are still
+returned correctly when other sparse fieldsets are used.

--- a/tests/Feature/Api/MetaExtractionApiTest.php
+++ b/tests/Feature/Api/MetaExtractionApiTest.php
@@ -75,6 +75,49 @@ class MetaExtractionApiTest extends TestCase
             ->assertJsonPath('data.image', 'https://example.com/image.jpg');
     }
 
+    public function test_extraction_exposes_currency_and_locale_from_the_resolved_store(): void
+    {
+        SettingsHelper::setSetting('default_locale_settings', ['locale' => 'en_AU', 'currency' => 'AUD']);
+
+        Store::factory()->create([
+            'user_id' => $this->user->id,
+            'domains' => [
+                ['domain' => parse_url($this->url, PHP_URL_HOST)],
+            ],
+            'settings' => [
+                'scraper_service' => 'http',
+                'scraper_service_settings' => '',
+                'locale_settings' => ['currency' => 'GBP', 'locale' => 'en_GB'],
+            ],
+        ]);
+
+        $this->mockScrape('$35.00', 'Example product', 'https://example.com/image.jpg');
+
+        $this->postJson('/api/meta-extraction', ['url' => $this->url])
+            ->assertOk()
+            ->assertJsonPath('data.currency', 'GBP')
+            ->assertJsonPath('data.locale', 'en-GB')
+            ->assertJsonPath('data.store.currency', 'GBP')
+            ->assertJsonPath('data.store.locale', 'en-GB');
+    }
+
+    public function test_extraction_falls_back_to_the_app_currency_and_locale_without_a_store(): void
+    {
+        SettingsHelper::setSetting('default_locale_settings', ['locale' => 'en_AU', 'currency' => 'AUD']);
+
+        $this->configureProviders(['feature_providers' => ['healing' => '__disabled__']]);
+        $this->fakeHtml($this->healHtml());
+        $this->mockAgent([], 'never');
+
+        $response = $this->postJson('/api/meta-extraction', ['url' => $this->url]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.currency', 'AUD')
+            ->assertJsonPath('data.locale', 'en-AU');
+
+        $this->assertEmpty($response->json('data.store'));
+    }
+
     public function test_can_extract_meta_using_store_override(): void
     {
         $this->mockScrape('$19.99', 'Override product', 'https://example.com/override.jpg');

--- a/tests/Feature/Api/StoreApiTest.php
+++ b/tests/Feature/Api/StoreApiTest.php
@@ -127,11 +127,48 @@ class StoreApiTest extends TestCase
         ]);
 
         // `settings` is not requested, but the currency/locale accessors read from it.
+        // It is selected internally to resolve them, and must not leak into the response.
         $this->getJson('/api/stores?fields[stores]=id,name')
             ->assertSuccessful()
             ->assertJsonPath('data.0.id', $store->id)
             ->assertJsonPath('data.0.currency', 'GBP')
-            ->assertJsonPath('data.0.locale', 'en-GB');
+            ->assertJsonPath('data.0.locale', 'en-GB')
+            ->assertJsonMissingPath('data.0.settings');
+    }
+
+    public function test_sparse_fieldset_returns_settings_when_it_is_requested(): void
+    {
+        $store = Store::factory()->create([
+            'user_id' => $this->user->id,
+            'settings' => ['locale_settings' => ['currency' => 'GBP', 'locale' => 'en_GB']],
+        ]);
+
+        $this->getJson('/api/stores?fields[stores]=id,settings')
+            ->assertSuccessful()
+            ->assertJsonPath('data.0.id', $store->id)
+            ->assertJsonPath('data.0.settings.locale_settings.currency', 'GBP');
+    }
+
+    public function test_empty_locale_overrides_fall_back_to_the_app_defaults(): void
+    {
+        SettingsHelper::setSetting('default_locale_settings', ['locale' => 'en_AU', 'currency' => 'AUD']);
+
+        // An explicitly null override is not the same as an absent one: the accessors use
+        // data_get(), which only falls back when the key is missing.
+        $store = Store::factory()->create([
+            'user_id' => $this->user->id,
+            'settings' => ['locale_settings' => ['currency' => null, 'locale' => null]],
+        ]);
+
+        $this->getJson('/api/stores')
+            ->assertSuccessful()
+            ->assertJsonPath('data.0.currency', 'AUD')
+            ->assertJsonPath('data.0.locale', 'en-AU');
+
+        $this->getJson("/api/stores/{$store->id}")
+            ->assertSuccessful()
+            ->assertJsonPath('data.currency', 'AUD')
+            ->assertJsonPath('data.locale', 'en-AU');
     }
 
     public function test_cannot_show_other_users_store(): void

--- a/tests/Feature/Api/StoreApiTest.php
+++ b/tests/Feature/Api/StoreApiTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Api;
 use App\Enums\ScraperService;
 use App\Models\Store;
 use App\Models\User;
+use App\Services\Helpers\SettingsHelper;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -76,6 +77,61 @@ class StoreApiTest extends TestCase
                     'name' => $store->name,
                 ],
             ]);
+    }
+
+    public function test_list_includes_resolved_currency_and_locale(): void
+    {
+        SettingsHelper::setSetting('default_locale_settings', ['locale' => 'en_AU', 'currency' => 'AUD']);
+
+        $withOverride = Store::factory()->create([
+            'user_id' => $this->user->id,
+            'settings' => ['locale_settings' => ['currency' => 'GBP', 'locale' => 'en_GB']],
+        ]);
+        $withoutOverride = Store::factory()->create(['user_id' => $this->user->id]);
+
+        $response = $this->getJson('/api/stores?sort=id');
+
+        $response->assertSuccessful()
+            ->assertJsonStructure(['data' => ['*' => ['currency', 'locale']]]);
+
+        $byId = collect($response->json('data'))->keyBy('id');
+
+        $this->assertSame('GBP', $byId[$withOverride->id]['currency']);
+        $this->assertSame('en-GB', $byId[$withOverride->id]['locale']);
+        $this->assertSame('AUD', $byId[$withoutOverride->id]['currency']);
+        $this->assertSame('en-AU', $byId[$withoutOverride->id]['locale']);
+    }
+
+    public function test_show_includes_resolved_currency_and_locale(): void
+    {
+        SettingsHelper::setSetting('default_locale_settings', ['locale' => 'en_AU', 'currency' => 'AUD']);
+
+        $store = Store::factory()->create([
+            'user_id' => $this->user->id,
+            'settings' => ['locale_settings' => ['currency' => 'GBP', 'locale' => 'en_GB']],
+        ]);
+
+        $this->getJson("/api/stores/{$store->id}")
+            ->assertSuccessful()
+            ->assertJsonPath('data.currency', 'GBP')
+            ->assertJsonPath('data.locale', 'en-GB');
+    }
+
+    public function test_sparse_fieldset_still_reports_the_stores_own_currency(): void
+    {
+        SettingsHelper::setSetting('default_locale_settings', ['locale' => 'en_AU', 'currency' => 'AUD']);
+
+        $store = Store::factory()->create([
+            'user_id' => $this->user->id,
+            'settings' => ['locale_settings' => ['currency' => 'GBP', 'locale' => 'en_GB']],
+        ]);
+
+        // `settings` is not requested, but the currency/locale accessors read from it.
+        $this->getJson('/api/stores?fields[stores]=id,name')
+            ->assertSuccessful()
+            ->assertJsonPath('data.0.id', $store->id)
+            ->assertJsonPath('data.0.currency', 'GBP')
+            ->assertJsonPath('data.0.locale', 'en-GB');
     }
 
     public function test_cannot_show_other_users_store(): void


### PR DESCRIPTION
The extension renders the same price two ways: Insights reads currency from price_cache[].currency, but /api/meta-extraction returns a bare price with no currency anywhere, so the Track tab can't format it. Store::currency and Store::locale are accessors, not in $appends, so they never reach toArray(). Reading the raw settings blob is not a workaround - most stores have no locale_settings key, so the real value only exists once the accessor applies the app-config fallback.

Adds the resolved accessor values (ISO 4217 code, BCP-47 tag) to:

- StoreResource, which meta-extraction embeds as `store`
- MetaExtractionResource, at the top level next to `price`, falling back to the app defaults when no store resolved and `store` is `{}`
- StoreTransformer, so GET /api/stores can format prices too

Locale is converted from the stored ICU form (en_AU) to BCP-47 (en-AU) at the API boundary; Intl.NumberFormat rejects the underscore form. The accessors and stored settings are unchanged.

currency/locale are deliberately absent from PaginationHandler's allowed fields, since Spatie translates those into a select() and these are accessors, not columns. Instead, a sparse fieldset forces `settings` into the select so the accessors read real data rather than silently reporting the app-level fallback.

Purely additive; no existing field changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Store and meta-extraction responses now include resolved currency and BCP-47 locale information.
  * Store-specific settings are reflected when available, with application defaults used as fallback.
  * Currency and locale fields are supported in embedded store data and sparse responses, including explicit settings requests.

* **Documentation**
  * Updated API documentation to describe computed fields and fallback behavior.

* **Bug Fixes**
  * Improved locale formatting for consistent standards-compliant output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->