### PR TITLE
fix: stop long product titles wrecking the view page header

### DIFF
--- a/app/Filament/Resources/ProductResource/Pages/ViewProduct.php
+++ b/app/Filament/Resources/ProductResource/Pages/ViewProduct.php
@@ -8,6 +8,7 @@ use App\Filament\Resources\ProductResource;
 use App\Models\Product;
 use Filament\Resources\Pages\ViewRecord;
 use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\HtmlString;
 
 /**
  * @property Product $record
@@ -21,6 +22,19 @@ class ViewProduct extends ViewRecord
     public function getTitle(): string|Htmlable
     {
         return $this->record->title;
+    }
+
+    /**
+     * Scraped titles run long, so clamp the heading to a couple of lines rather than letting
+     * it push the header actions down the page. The full title stays available on hover.
+     */
+    public function getHeading(): string|Htmlable
+    {
+        return new HtmlString(sprintf(
+            '<span class="block max-w-3xl line-clamp-2 md:line-clamp-3" title="%s">%s</span>',
+            e($this->record->title),
+            e($this->record->title),
+        ));
     }
 
     protected function getHeaderActions(): array

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -459,13 +459,13 @@ class Product extends Model
     }
 
     /**
-     * Truncate long titles.
+     * Truncate long titles and strip the site name noise stores append to them.
      */
     public function title(): Attribute
     {
         return Attribute::make(
             get: fn ($v) => ScrapeUrl::preSaveTruncate($v),
-            set: fn ($v) => ScrapeUrl::preSaveTruncate($v)
+            set: fn ($v) => ScrapeUrl::preSaveTruncate(ScrapeUrl::preSaveCleanTitle($v))
         );
     }
 

--- a/app/Models/Url.php
+++ b/app/Models/Url.php
@@ -340,7 +340,7 @@ class Url extends Model
             $image = data_get($scrape, 'image');
 
             $productId = Product::create([
-                'title' => data_get($scrape, 'title'),
+                'title' => ScrapeUrl::preSaveCleanTitle(data_get($scrape, 'title'), $store->name),
                 'image' => strlen($image) < ScrapeUrl::MAX_STR_LENGTH ? $image : null,
                 'user_id' => $userId,
                 'favourite' => true,

--- a/app/Services/ScrapeUrl.php
+++ b/app/Services/ScrapeUrl.php
@@ -31,6 +31,27 @@ class ScrapeUrl
      */
     public const int MAX_STR_LENGTH = 1000;
 
+    /**
+     * Splits a title on its last separator, eg the ":" in "Wireless Mouse: Amazon.com.au".
+     * A dash only counts when surrounded by whitespace so hyphenated words survive.
+     */
+    protected const string TITLE_SEPARATOR_PATTERN = '/^(?P<head>.*\S)(?:\s*[|:»·]\s*|\s+[-–—]\s+)(?P<tail>[^|:»·]+?)\s*$/u';
+
+    /**
+     * A segment that is nothing but a hostname, eg "Amazon.com.au" or "www.kogan.com".
+     */
+    protected const string TITLE_DOMAIN_PATTERN = '/^(?:www\.)?[\p{L}\p{N}][\p{L}\p{N}-]*(?:\.\p{L}{2,})+$/u';
+
+    /**
+     * How many trailing noise segments to strip from a title before giving up.
+     */
+    protected const int TITLE_MAX_NOISE_SEGMENTS = 5;
+
+    /**
+     * Shortest title we are willing to leave behind after stripping noise.
+     */
+    protected const int TITLE_MIN_LENGTH = 3;
+
     protected WebScraperInterface $webScraper;
 
     protected LoggerInterface $logger;
@@ -398,5 +419,52 @@ class ScrapeUrl
     public static function preSaveTruncate(?string $value): ?string
     {
         return Str::limit($value, self::MAX_STR_LENGTH);
+    }
+
+    /**
+     * Strip the site name noise stores append to product titles, eg the ": Mice: Amazon.com.au"
+     * in "Wireless Gaming Mouse (Black): Mice: Amazon.com.au". Only trailing segments that are
+     * a bare hostname or the store's own name are removed, so product detail is never lost.
+     */
+    public static function preSaveCleanTitle(?string $value, ?string $storeName = null): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $title = trim((string) preg_replace('/\s+/u', ' ', $value));
+        $storeName = $storeName === null ? null : mb_strtolower(trim($storeName));
+
+        for ($i = 0; $i < self::TITLE_MAX_NOISE_SEGMENTS; $i++) {
+            if (! preg_match(self::TITLE_SEPARATOR_PATTERN, $title, $matches)) {
+                break;
+            }
+
+            if (! self::isTitleNoiseSegment($matches['tail'], $storeName)) {
+                break;
+            }
+
+            if (mb_strlen($matches['head']) < self::TITLE_MIN_LENGTH) {
+                break;
+            }
+
+            $title = $matches['head'];
+        }
+
+        return $title;
+    }
+
+    /**
+     * Is this trailing title segment site name noise rather than product detail?
+     */
+    protected static function isTitleNoiseSegment(string $segment, ?string $storeName): bool
+    {
+        $segment = trim($segment);
+
+        if ($storeName !== null && $storeName !== '' && mb_strtolower($segment) === $storeName) {
+            return true;
+        }
+
+        return (bool) preg_match(self::TITLE_DOMAIN_PATTERN, $segment);
     }
 }

--- a/resources/scss/_trumps.scss
+++ b/resources/scss/_trumps.scss
@@ -77,6 +77,12 @@
             padding-left: 2rem;
         }
     }
+
+    // Product titles wrap over several lines, so keep the actions level with the first line
+    // instead of floating in the middle of the heading (Filament defaults to sm:items-center).
+    .product-view .fi-header {
+        align-items: flex-start;
+    }
 }
 
 @media screen and (max-width: 640px) {

--- a/tests/Feature/Filament/ViewProductHeadingTest.php
+++ b/tests/Feature/Filament/ViewProductHeadingTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature\Filament;
+
+use App\Filament\Resources\ProductResource;
+use App\Models\Product;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ViewProductHeadingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    const LONG_TITLE = 'DAREU A950GM Wireless Gaming Mouse (Black), 60g ultra-lightweight ergonomic design with USB-C, 2.4GHz and Bluetooth tri-mode connectivity, PAW3395 sensor and CX52850 MCU';
+
+    public function test_long_heading_is_clamped_but_keeps_the_full_title_on_hover(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $product = Product::factory()->create([
+            'user_id' => $user->getKey(),
+            'title' => self::LONG_TITLE,
+        ]);
+
+        $response = $this->get(ProductResource::getUrl('view', ['record' => $product]));
+
+        $response->assertOk();
+        $response->assertSee('line-clamp-2', false);
+        $response->assertSee('title="'.e(self::LONG_TITLE).'"', false);
+    }
+}

--- a/tests/Feature/Models/ProductTest.php
+++ b/tests/Feature/Models/ProductTest.php
@@ -415,6 +415,28 @@ class ProductTest extends TestCase
         $this->assertStringEndsWith('...', $product->title);
     }
 
+    public function test_title_mutator_strips_trailing_site_name_noise()
+    {
+        $product = Product::factory()->createOne([
+            'title' => 'DAREU A950GM Wireless Gaming Mouse (Black): Mice: Amazon.com.au',
+        ]);
+
+        $this->assertEquals('DAREU A950GM Wireless Gaming Mouse (Black): Mice', $product->title);
+        $this->assertDatabaseHas('products', [
+            'id' => $product->getKey(),
+            'title' => 'DAREU A950GM Wireless Gaming Mouse (Black): Mice',
+        ]);
+    }
+
+    public function test_title_mutator_keeps_titles_without_site_name_noise()
+    {
+        $product = Product::factory()->createOne([
+            'title' => 'Dyson V15 Detect | 2024 Model',
+        ]);
+
+        $this->assertEquals('Dyson V15 Detect | 2024 Model', $product->title);
+    }
+
     public function test_image_mutator_sets_null_for_long_strings()
     {
         $shortImage = 'https://example.com/image.jpg';

--- a/tests/Feature/Models/UrlTest.php
+++ b/tests/Feature/Models/UrlTest.php
@@ -66,6 +66,20 @@ class UrlTest extends TestCase
         $this->assertEquals($scrapeData['title'], $urlModel->product->title);
     }
 
+    public function test_create_from_url_strips_the_store_name_from_the_product_title()
+    {
+        $this->actingAs($this->user);
+
+        $this->store->update(['name' => 'JB Hi-Fi']);
+
+        $this->mockScrape(100, 'Sony WH-1000XM5 Wireless Headphones | JB Hi-Fi');
+
+        $urlModel = Url::createFromUrl(self::TEST_URL);
+
+        $this->assertInstanceOf(Url::class, $urlModel);
+        $this->assertEquals('Sony WH-1000XM5 Wireless Headphones', $urlModel->product->title);
+    }
+
     public function test_create_from_url_with_invalid_data()
     {
         $this->mockScrape('', '');

--- a/tests/Unit/Services/ScrapeUrlCleanTitleTest.php
+++ b/tests/Unit/Services/ScrapeUrlCleanTitleTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\ScrapeUrl;
+use PHPUnit\Framework\TestCase;
+
+class ScrapeUrlCleanTitleTest extends TestCase
+{
+    public function test_strips_a_trailing_domain_segment(): void
+    {
+        $this->assertSame(
+            'DAREU A950GM Wireless Gaming Mouse (Black): Mice',
+            ScrapeUrl::preSaveCleanTitle('DAREU A950GM Wireless Gaming Mouse (Black): Mice: Amazon.com.au')
+        );
+    }
+
+    public function test_strips_a_trailing_domain_segment_after_a_pipe(): void
+    {
+        $this->assertSame(
+            'Logitech MX Master 3S',
+            ScrapeUrl::preSaveCleanTitle('Logitech MX Master 3S | Kogan.com')
+        );
+    }
+
+    public function test_strips_a_trailing_segment_matching_the_store_name(): void
+    {
+        $this->assertSame(
+            'Sony WH-1000XM5 Wireless Headphones',
+            ScrapeUrl::preSaveCleanTitle('Sony WH-1000XM5 Wireless Headphones | JB Hi-Fi', 'JB Hi-Fi')
+        );
+    }
+
+    public function test_strips_repeated_trailing_noise_segments(): void
+    {
+        $this->assertSame(
+            'Anker 737 Power Bank',
+            ScrapeUrl::preSaveCleanTitle('Anker 737 Power Bank | Amazon AU | amazon.com.au', 'Amazon AU')
+        );
+    }
+
+    public function test_keeps_a_trailing_segment_that_is_product_information(): void
+    {
+        $this->assertSame(
+            'Dyson V15 Detect | 2024 Model',
+            ScrapeUrl::preSaveCleanTitle('Dyson V15 Detect | 2024 Model')
+        );
+    }
+
+    public function test_does_not_strip_hyphenated_words(): void
+    {
+        $this->assertSame(
+            'DAREU A950GM 60g ultra-lightweight ergonomic design',
+            ScrapeUrl::preSaveCleanTitle('DAREU A950GM 60g ultra-lightweight ergonomic design')
+        );
+    }
+
+    public function test_strips_a_trailing_segment_after_a_spaced_dash(): void
+    {
+        $this->assertSame(
+            'Samsung 990 Pro 2TB SSD',
+            ScrapeUrl::preSaveCleanTitle('Samsung 990 Pro 2TB SSD - Scorptec.com.au')
+        );
+    }
+
+    public function test_leaves_a_title_that_is_only_a_domain_alone(): void
+    {
+        $this->assertSame('Amazon.com.au', ScrapeUrl::preSaveCleanTitle('Amazon.com.au'));
+    }
+
+    public function test_collapses_whitespace_and_trims(): void
+    {
+        $this->assertSame('Razer Basilisk V3', ScrapeUrl::preSaveCleanTitle("  Razer \n Basilisk V3  | Razer.com"));
+    }
+
+    public function test_leaves_null_and_empty_values_alone(): void
+    {
+        $this->assertNull(ScrapeUrl::preSaveCleanTitle(null));
+        $this->assertSame('', ScrapeUrl::preSaveCleanTitle(''));
+    }
+}


### PR DESCRIPTION
Scraped titles run to hundreds of characters, so the view page heading wrapped to eight lines and Filament's sm:items-center left the header actions floating in the middle of it.

- Clamp the heading to 2 lines (3 from md) with the full title on hover, via getHeading() so the browser tab title stays plain text.
- Align the header actions to the top of the heading on the product view.
- Strip the site name noise stores append to titles ("...: Mice: Amazon.com.au") on save, using the store name where it is known.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Product titles are cleaned to remove trailing store names and website domains.
  * Long product headings now display in a compact two-line layout, with the full title available on hover.

* **Bug Fixes**
  * Improved title formatting and whitespace handling while preserving meaningful product information.
  * Updated product page header alignment for desktop displays.

* **Tests**
  * Added coverage for title cleanup, long headings, and scraped product titles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->