### PR TITLE
fix(dashboard): format Potential savings stat with configured currency

### DIFF
--- a/docs/plans/196-potential-savings-currency.md
+++ b/docs/plans/196-potential-savings-currency.md
@@ -1,0 +1,114 @@
+---
+title: "Fix #196: Potential Savings stat uses configured currency"
+created: 2026-08-09
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-plan-bootstrap
+plan_model: session
+---
+
+# Fix #196: "Potential Savings" stat currency hardcoded to dollars
+
+## Problem Frame
+
+The dashboard "Potential savings" stat always renders a `$` prefix regardless of the
+user's configured locale/currency. The savings figure itself is computed correctly in
+the user's default currency, so a user on EUR/GBP/AUD sees a mislabeled value.
+
+## Goal Capsule
+
+Make the "Potential savings" dashboard stat format the savings value with the
+configured default currency and locale, consistent with every other price display in
+the app (e.g. min/avg/max aggregates, product cards).
+
+## Scope
+
+**In scope**
+
+- The dashboard stat cell rendered by `resources/views/filament/widgets/dashboard/stat-bar.blade.php` (Potential savings cell only).
+- A regression test asserting non-USD configuration renders the configured currency.
+
+**Out of scope**
+
+- Other hardcoded or stale-currency displays elsewhere (e.g. `PriceCacheDto` cached-currency mismatch, issue #124) — separate issue, not addressed here.
+- Store-level currency handling.
+
+## Success Criteria
+
+- With `default_locale_settings.currency` set to a non-USD currency, the Potential
+  savings cell renders that currency's symbol/ISO formatting, not `$`.
+- With default USD settings, output is equivalent in meaning to before (a USD-formatted value).
+- Existing dashboard tests still pass.
+
+## Decisions
+
+- **D1 — Format via `CurrencyHelper::toString`** (governs unit 1). The app already
+  formats every other price display with `CurrencyHelper::toString(mixed $value, int $maxPrecision = 2, ?string $locale = null, ?string $iso = null)`
+  (see `app/Services/Helpers/CurrencyHelper.php:80`, which delegates to
+  `Illuminate\Support\Number::currency` with the configured default locale/currency).
+  Rejected: keeping `$`.number_format (wrong symbol); formatting in the widget class
+  `DashboardSections` (the view layer already receives a numeric value, and other stat
+  cells pass raw numbers to the view — keep the cell source unchanged).
+- **D2 — Pattern: `@php use` import in the blade.** Follow the existing
+  `resources/views/body/js-settings.blade.php:2` pattern of importing
+  `App\Services\Helpers\CurrencyHelper` inside a `@php` block rather than FQCN inline.
+
+## Implementation Units
+
+### Unit 1 — Format Potential savings with configured currency
+
+**Files**
+
+- `resources/views/filament/widgets/dashboard/stat-bar.blade.php` (modified)
+
+**Change**
+
+Add a `@php` block importing `App\Services\Helpers\CurrencyHelper`, and change the
+"Potential savings" cell value from:
+
+```php
+'$'.number_format($stats['potentialSavings'], 2)
+```
+
+to:
+
+```php
+CurrencyHelper::toString($stats['potentialSavings'])
+```
+
+The other four cells (counts) remain unchanged; `$stats` structure is unchanged.
+
+**Test scenarios** (`tests/Feature/View/StatBarTest.php`, new)
+
+1. `test_potential_savings_uses_configured_currency`: set
+   `SettingsHelper`/settings `default_locale_settings.currency` to a non-USD currency
+   (e.g. `EUR`) and `default_locale_settings.locale` to a matching locale (e.g.
+   `en_IE`), render `view('filament.widgets.dashboard.stat-bar', ['stats' => ['tracked' => 1, 'atLowest' => 1, 'belowAverage' => 1, 'outOfStock' => 0, 'potentialSavings' => 123.45]])`,
+   assert the output contains the EUR symbol (e.g. `€`) and does not contain `$123.45`.
+2. `test_potential_savings_usd_default_renders_dollar_value`: with default settings,
+   render the same view and assert the formatted USD value appears.
+
+Follow the existing view-test pattern in `tests/Feature/View/ProductBadgesTest.php`
+(`$this->blade()` / `view()` + `assertSee`).
+
+## Dependencies & Sequencing
+
+- Unit 1 is the only unit; no sequencing constraints.
+- Run `php artisan test --filter=StatBarTest` plus the existing dashboard test group
+  (`tests/Feature/Filament/HomeDashboardTest.php`, `tests/Feature/Widgets/ProductStatsTest.php`,
+  `tests/Feature/Services/Dashboard/DashboardSectionsTest.php`) to confirm no regression.
+
+## Risks
+
+- **Currency symbol vs ISO code rendering**: `Number::currency` may render
+  "€1,234.50" or "EUR 1,234.50" depending on locale. The test asserts the EUR symbol
+  under `en_IE`; if the harness renders differently for that locale, assert on the
+  locale-formatted string instead. Low risk — behavior is delegated to the same
+  helper every other display uses.
+
+## References
+
+- Origin: https://github.com/jez500/pricebuddy/issues/196
+- Offending line: `resources/views/filament/widgets/dashboard/stat-bar.blade.php:7`
+- Savings source: `app/Services/Dashboard/DashboardSections.php:66`

--- a/resources/views/filament/widgets/dashboard/stat-bar.blade.php
+++ b/resources/views/filament/widgets/dashboard/stat-bar.blade.php
@@ -1,11 +1,15 @@
 <div class="grid grid-cols-2 md:grid-cols-5 gap-4 mb-8">
-    @php($cells = [
-        ['label' => 'Tracked', 'value' => $stats['tracked']],
-        ['label' => 'All-time low', 'value' => $stats['atLowest']],
-        ['label' => 'Below average', 'value' => $stats['belowAverage']],
-        ['label' => 'Out of stock', 'value' => $stats['outOfStock']],
-        ['label' => 'Potential savings', 'value' => '$'.number_format($stats['potentialSavings'], 2)],
-    ])
+    @php
+        use App\Services\Helpers\CurrencyHelper;
+
+        $cells = [
+            ['label' => 'Tracked', 'value' => $stats['tracked']],
+            ['label' => 'All-time low', 'value' => $stats['atLowest']],
+            ['label' => 'Below average', 'value' => $stats['belowAverage']],
+            ['label' => 'Out of stock', 'value' => $stats['outOfStock']],
+            ['label' => 'Potential savings', 'value' => CurrencyHelper::toString($stats['potentialSavings'])],
+        ];
+    @endphp
     @foreach ($cells as $cell)
         <div class="fi-wi-stats-overview-stat rounded-xl bg-white dark:bg-gray-900 ring-1 ring-gray-950/5 dark:ring-white/10 p-4">
             <div class="text-sm text-gray-500 dark:text-gray-400">{{ $cell['label'] }}</div>

--- a/tests/Feature/View/StatBarTest.php
+++ b/tests/Feature/View/StatBarTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Feature\View;
+
+use App\Services\Helpers\SettingsHelper;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class StatBarTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        SettingsHelper::$settings = null;
+        SettingsHelper::setSetting('default_locale_settings', ['locale' => 'en', 'currency' => 'USD']);
+    }
+
+    private function renderStatBar(array $overrides = []): string
+    {
+        $stats = array_merge([
+            'tracked' => 10,
+            'atLowest' => 2,
+            'belowAverage' => 3,
+            'outOfStock' => 1,
+            'potentialSavings' => 123.45,
+        ], $overrides);
+
+        return $this->view('filament.widgets.dashboard.stat-bar', ['stats' => $stats])->render();
+    }
+
+    public function test_potential_savings_uses_configured_currency(): void
+    {
+        SettingsHelper::setSetting('default_locale_settings', ['locale' => 'en_IE', 'currency' => 'EUR']);
+
+        $html = $this->renderStatBar();
+
+        $this->assertStringContainsString('€', $html);
+        $this->assertStringNotContainsString('$123.45', $html);
+    }
+
+    public function test_potential_savings_usd_default_renders_dollar_value(): void
+    {
+        $html = $this->renderStatBar(['potentialSavings' => 123.45]);
+
+        $this->assertStringContainsString('$123.45', $html);
+    }
+}

--- a/tests/Feature/View/StatBarTest.php
+++ b/tests/Feature/View/StatBarTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\View;
 
+use App\Services\Helpers\CurrencyHelper;
 use App\Services\Helpers\SettingsHelper;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -16,6 +17,13 @@ class StatBarTest extends TestCase
 
         SettingsHelper::$settings = null;
         SettingsHelper::setSetting('default_locale_settings', ['locale' => 'en', 'currency' => 'USD']);
+    }
+
+    protected function tearDown(): void
+    {
+        SettingsHelper::$settings = null;
+
+        parent::tearDown();
     }
 
     private function renderStatBar(array $overrides = []): string
@@ -37,11 +45,12 @@ class StatBarTest extends TestCase
 
         $html = $this->renderStatBar();
 
+        $this->assertStringContainsString(CurrencyHelper::toString(123.45), $html);
         $this->assertStringContainsString('€', $html);
         $this->assertStringNotContainsString('$123.45', $html);
     }
 
-    public function test_potential_savings_usd_default_renders_dollar_value(): void
+    public function test_potential_savings_configured_usd_renders_dollar_value(): void
     {
         $html = $this->renderStatBar(['potentialSavings' => 123.45]);
 


### PR DESCRIPTION
The dashboard "Potential savings" stat now renders in the configured default currency and locale instead of a hardcoded dollar sign. A user on EUR/GBP/AUD previously saw a `$` value that did not match the rest of their dashboard; the stat now uses the same `CurrencyHelper` formatting as the min/avg/max aggregates and product cards.

Fixes #196

Tests: new `tests/Feature/View/StatBarTest.php` covers configured-currency (EUR) and USD rendering of the stat cell. The full suite runs in CI (`php artisan test`); a local run was not possible in this environment (no PHP/Docker), so CI is the verification run.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Potential savings on the dashboard now respects the configured currency and locale.
  - Values display correctly for currencies such as EUR and USD.

- **Tests**
  - Added coverage to verify currency formatting and prevent regressions.

- **Documentation**
  - Added an implementation plan documenting the currency-formatting change and verification steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->