### PR TITLE
docs: removed build from docker-compose and updated docs about pre-bu…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,6 @@
 services:
 
     app:
-        build:
-            context: .
-            dockerfile: docker/php.dockerfile
         image: jez500/pricebuddy:latest
         ports:
             - 8080:80

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -4,6 +4,9 @@ The recommended way to install PriceBuddy is via Docker. This will ensure that a
 dependencies are installed and configured correctly. A `docker-compose.yml` file is
 provided to make this easy.
 
+Pre-built docker images can be found on Docker Hub for [PriceBuddy](https://hub.docker.com/r/jez500/pricebuddy)
+and [Seleniumbase Scrapper](https://hub.docker.com/r/jez500/seleniumbase-scrapper).
+
 ## Quick start
 
 ```shell


### PR DESCRIPTION
…ilt images

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The application now uses a pre-built Docker image for easier setup and deployment.
  * Installation instructions now include pre-built Docker images for PriceBuddy and the Seleniumbase Scrapper.

* **Documentation**
  * Updated installation guidance to reflect the streamlined Docker-based setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->